### PR TITLE
wxPython on mac requires python execution in 32-bit mode. Hard to debug

### DIFF
--- a/BUILD.rest
+++ b/BUILD.rest
@@ -23,6 +23,14 @@ for more information.
 __ http://paver.github.com/paver
 
 
+MacOS 10.7+
+-----------
+wxPython is limited to running in 32-bit mode.
+Python itself should thus be executed in 32-bit mode. This can be done by setting:
+
+  export VERSIONER_PYTHON_PREFER_32_BIT=yes
+
+
 Repository contents
 ===================
 

--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -44,8 +44,11 @@ try:
     if "ansi" in wx.PlatformInfo:
         print errorMessageTemplate.substitute(reason="wxPython with ansi encoding is not supported", versions=" or ".join(supported_versions))
         sys.exit(1)
-except ImportError:
-    print errorMessageTemplate.substitute(reason="wxPython not found.", versions=" or ".join(supported_versions))
+except ImportError as e:
+    if "no appropriate 64-bit architecture" in e.message.lower() and sys.platform == 'darwin':
+        print "python should be executed in 32-bit mode to support wxPython on mac. Check BUILD.rest for details"
+    else:
+        print errorMessageTemplate.substitute(reason="wxPython not found.", versions=" or ".join(supported_versions))
     sys.exit(1)
 except VersionError:
     print errorMessageTemplate.substitute(reason="Wrong wxPython version.", versions=" or ".join(supported_versions))


### PR DESCRIPTION
While starting to setup the robotframework environment on Mac it was really hard to figure out why paver did not work.

After extensive effort the problem was 32(wxPython) vs 64(python) bit mode.

I hope my changes and help others starting out with this.

Charandeep
