### PR TITLE
Small fix for read-only installations

### DIFF
--- a/src/robotide/preferences/settings.py
+++ b/src/robotide/preferences/settings.py
@@ -42,14 +42,14 @@ def _copy_or_migrate_user_settings(settings_dir, source_path, dest_file_name):
         dest_file_name = os.path.basename(source_path)
     settings_path = os.path.join(settings_dir, dest_file_name)
     if not os.path.exists(settings_path):
-        shutil.copy(source_path, settings_path)
+        shutil.copyfile(source_path, settings_path)
     else:
         try:
             SettingsMigrator(source_path, settings_path).migrate()
         except ConfigObjError, parsing_error:
             print 'WARNING! corrupted configuration file replaced with defaults'
             print parsing_error
-            shutil.copy(source_path, settings_path)
+            shutil.copyfile(source_path, settings_path)
     return os.path.abspath(settings_path)
 
 class SettingsMigrator(object):


### PR DESCRIPTION
When RIDE is installed in read-only locations users are faced with this
the first time they run it:

 IOError: [Errno 13] Permission denied: '/home/bfo/.robotframework/ride/settings.cfg'

This happens because shutil.copy copies the read-only permission bits
from settings.cfg in the install path over to the users home directory.
By using shutil.copyfile instead, like this patch does, only the file
contents is copied and not the permission bits, so the file ends up
being writeable for the user.

This patch is specifically needed for the Nix package system where
applications are "locked down" in read-only paths.
