### PR TITLE
Fixed the NameError when running paver builder by pavement.py

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from os.path import join, isdir, isfile
 import csv


### PR DESCRIPTION
sys module is refenced in pavement.py, but it is not imported. 
