### PR TITLE
path name with "&" should be supported

### DIFF
--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -416,7 +416,7 @@ class TestRunnerPlugin(Plugin):
         '''
         result = []
         for arg in argv:
-            if "'" in arg or " " in arg:
+            if "'" in arg or " " in arg or "&" in arg:
                 # for windows, if there are spaces we need to use
                 # double quotes. Single quotes cause problems
                 result.append('"%s"' % arg)


### PR DESCRIPTION
it may report an error as below,
this is because of the robotframework_ride not handle the special
characters "&" when it  format the  command, one way of handle this
exception is modify the file:
C:\Python27\Lib\site-packages\robotframework_ride-x.x.x-pyx.x.egg\robotide\contrib\testrunner\
testrunnerplugin.py .