### PR TITLE
Remove Python 2.5 compatibility

### DIFF
--- a/src/robotide/application/application.py
+++ b/src/robotide/application/application.py
@@ -12,11 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from __future__ import with_statement
 import os
 import wx
 from contextlib import contextmanager
-from robotide.application.updatenotifier import UpdateNotifierController, UpdateDialog
 
 from robotide.namespace import Namespace
 from robotide.controller import Project
@@ -26,10 +24,12 @@ from robotide.ui.mainframe import RideFrame
 from robotide.pluginapi import RideLogMessage
 from robotide import context, contrib
 from robotide.preferences import Preferences, RideSettings
-
-from pluginloader import PluginLoader
-from editorprovider import EditorProvider
+from robotide.application.pluginloader import PluginLoader
+from robotide.application.editorprovider import EditorProvider
 from robotide.application.releasenotes import ReleaseNotes
+from robotide.application.updatenotifier import UpdateNotifierController, \
+    UpdateDialog
+
 
 class RIDE(wx.App):
 

--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -42,30 +42,27 @@ linux it's /tmp).
 You can safely manually remove these directories, except for the one
 being used for a currently running test.
 '''
-from Queue import Queue
 import datetime
 import time
 import os
 import sys
-import posixpath
 import re
-from posixpath import curdir, sep, pardir, join
-from robot.output import LEVELS
-from robot.utils import robottime
-from robotide.action.shortcut import localize_shortcuts
-from robotide.contrib.testrunner.runprofiles import CustomScriptProfile
-from robotide.contrib.testrunner.testrunner import TestRunner
-from robotide.publish.messages import RideTestSelectedForRunningChanged, RideNewProject
-
-ON_POSIX = 'posix' in sys.builtin_module_names
-
+from Queue import Queue
 import wx
 import wx.stc
 from wx.lib.embeddedimage import PyEmbeddedImage
-from robotide.pluginapi import Plugin, ActionInfo
-from robotide.contrib.testrunner import runprofiles
-from robotide.widgets import Label, ImageProvider
+
+from robot.output import LEVELS
+from robot.utils import robottime
+
+from robotide.action.shortcut import localize_shortcuts
 from robotide.context import IS_WINDOWS, IS_MAC
+from robotide.contrib.testrunner.testrunner import TestRunner
+from robotide.contrib.testrunner import runprofiles
+from robotide.publish.messages import RideTestSelectedForRunningChanged, RideNewProject
+from robotide.pluginapi import Plugin, ActionInfo
+from robotide.widgets import Label, ImageProvider
+
 
 ID_RUN = wx.NewId()
 ID_STOP = wx.NewId()
@@ -80,24 +77,6 @@ ID_PAUSE_ON_FAILURE = wx.NewId()
 ID_SHOW_MESSAGE_LOG = wx.NewId()
 STYLE_STDERR = 2
 
-
-try:
-    from os.path import relpath
-except ImportError:
-    # the python 2.6 os.path package provides a relpath() function,
-    # but we're running 2.5 so we have to roll our own
-    def relpath(path, start=curdir):
-        """Return a relative version of a path"""
-        if not path:
-            raise ValueError("no path specified")
-        start_list = posixpath.abspath(start).split(sep)
-        path_list = posixpath.abspath(path).split(sep)
-        # Work out how much of the filepath is shared by start and path.
-        i = len(posixpath.commonprefix([start_list, path_list]))
-        rel_list = [pardir] * (len(start_list)-i) + path_list[i:]
-        if not rel_list:
-            return curdir
-        return join(*rel_list)
 
 def _RunProfile(name, run_prefix):
     return type('Profile', (runprofiles.PybotProfile,),
@@ -291,7 +270,7 @@ class TestRunnerPlugin(Plugin):
 
     def _get_current_working_dir(self):
         profile = self.get_current_profile()
-        if profile.name == CustomScriptProfile.name:
+        if profile.name == runprofiles.CustomScriptProfile.name:
             return profile.get_cwd()
         if not os.path.isdir(self.model.suite.source):
             return os.path.dirname(self.model.suite.source)

--- a/src/robotide/controller/project.py
+++ b/src/robotide/controller/project.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from __future__ import with_statement
 
 import os
 import shutil
@@ -47,8 +46,9 @@ class Project(_BaseController, WithNamespace):
         self._serializer = Serializer(settings, LOG)
 
     def _construct_library_manager(self, library_manager, settings):
-        return library_manager or LibraryManager(DATABASE_FILE,
-                                                 SpecInitializer(settings.get('library xml directories', [])[:]))
+        return library_manager or \
+            LibraryManager(DATABASE_FILE,
+                SpecInitializer(settings.get('library xml directories', [])[:]))
 
     def __del__(self):
         if self._library_manager:
@@ -96,7 +96,7 @@ class Project(_BaseController, WithNamespace):
     def resource_file_controller_factory(self):
         return self._resource_file_controller_factory
 
-    def find_controller_by_longname(self, longname, testname = None):
+    def find_controller_by_longname(self, longname, testname=None):
         return self._controller.find_controller_by_longname(longname, testname)
 
     def new_directory_project(self, path):

--- a/src/robotide/preferences/__init__.py
+++ b/src/robotide/preferences/__init__.py
@@ -14,8 +14,8 @@
 
 from .settings import Settings, initialize_settings, RideSettings
 from .editor import PreferenceEditor
-from .widgets import (PreferencesPanel, PreferencesComboBox,
-    PreferencesColorPicker)
+from .widgets import PreferencesPanel, PreferencesComboBox,\
+    PreferencesColorPicker
 from .imports import ImportPreferences
 from .saving import SavingPreferences
 from .colors import GridColorPreferences, TextEditColorPreferences

--- a/src/robotide/run/process.py
+++ b/src/robotide/run/process.py
@@ -24,10 +24,13 @@ class Process(object):
         self._command = self._parse_command(command)
         self._process = None
         self._error = None
+        self._out_file = None
+        self._out_path = None
+        self._out_fd = None
 
     def _parse_command(self, command):
         if isinstance(command, basestring):
-            return [ val.replace('<SPACE>', ' ') for val in command.split() ]
+            return [val.replace('<SPACE>', ' ') for val in command.split()]
         return command
 
     def start(self):
@@ -48,11 +51,7 @@ class Process(object):
         return self._error is not None or self._process.poll() is not None
 
     def stop(self):
-        try:
-            self._process.kill()
-        except AttributeError:
-            raise AttributeError('Stopping process is possible only with '
-                                 'Python 2.6 or newer')
+        self._process.kill()
 
     def wait(self):
         if self._process is not None:

--- a/utest/controller/test_backup.py
+++ b/utest/controller/test_backup.py
@@ -1,15 +1,14 @@
-from __future__ import with_statement
-
 import unittest
+
 from robotide.controller.project import Backup
 
 
 class BackupTestCase(unittest.TestCase):
 
     def setUp(self):
-        file_controller = lambda:0
+        file_controller = lambda: None
         file_controller.filename = 'some_filename.txt'
-        file_controller.refresh_stat = lambda:0
+        file_controller.refresh_stat = lambda: None
         self._backupper = _MyBackup(file_controller)
 
     def test_backup_is_restored_when_save_raises_exception(self):
@@ -23,7 +22,6 @@ class BackupTestCase(unittest.TestCase):
     def test_backup_is_not_restored_when_save_passes(self):
         with self._backupper:
             self.assertNotEqual(None, self._backupper._backup)
-            pass
         self.assertFalse(self._backupper.restored)
         self.assertEqual(None, self._backupper._backup)
 

--- a/utest/preferences/test_settings.py
+++ b/utest/preferences/test_settings.py
@@ -10,7 +10,7 @@ class SettingsMigrationTestCase(SettingsMigrator, unittest.TestCase):
 
     def setUp(self):
         self._old_settings = {}
-        self._default_settings = lambda:0
+        self._default_settings = lambda: 0
         self._from_0_to_1_called = False
         self._from_1_to_2_called = False
         self._merge_called = False

--- a/utest/resources/mocks.py
+++ b/utest/resources/mocks.py
@@ -1,4 +1,5 @@
-from robotide.preferences.settings import Settings, Excludes
+from robotide.preferences.settings import Settings
+from robotide.preferences.excludes import Excludes
 from robotide.publish import PUBLISHER
 
 

--- a/utest/run/test_process.py
+++ b/utest/run/test_process.py
@@ -1,12 +1,11 @@
 import unittest
 import os
-import sys
 
 from robotide.run.process import Process
 from robot.utils.asserts import assert_equals, assert_raises_with_msg
 
 
-SCRIPT = os.path.join(os.path.dirname(__file__), 
+SCRIPT = os.path.join(os.path.dirname(__file__),
                       'process_test_scripts.py').replace(' ', '<SPACE>')
 
 
@@ -17,12 +16,6 @@ class TestProcess(unittest.TestCase):
         processed_command = Process(initial_command)._command
         assert_equals(len(processed_command), len(initial_command.split()))
         assert_equals(processed_command[4], 'a2 2 1')
-
-    if sys.version_info[:2] < (2,6):
-        def test_stopping(self):
-                msg = 'Stopping process is possible only with Python 2.6 or newer'
-                assert_raises_with_msg(AttributeError, msg,
-                                       self._create_process(['']).stop)
 
     def test_writing_to_stderr(self):
         self.proc = self._create_process('python %s stderr' % SCRIPT)

--- a/utest/settings/test_settings.py
+++ b/utest/settings/test_settings.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import unittest
 import os
 from robotide.preferences import settings
@@ -293,11 +291,11 @@ class TestInitializeSettings(TestSettingsHelper):
         os.removedirs(self.settings_dir)
 
     def test_initialize_settings_creates_directory(self):
-        initialize_settings('user settings', self.settings_path, 'user.cfg')
+        initialize_settings(self.settings_path, 'user.cfg')
         self.assertTrue(os.path.exists(self.settings_dir))
 
     def test_initialize_settings_copies_settings(self):
-        initialize_settings('user settings', self.settings_path, 'user.cfg')
+        initialize_settings(self.settings_path, 'user.cfg')
         self.assertTrue(os.path.exists(self.settings_dir))
 
     def test_initialize_settings_does_merge_when_settings_exists(self):
@@ -306,7 +304,7 @@ class TestInitializeSettings(TestSettingsHelper):
             "foo = 'bar'\nhello = 'world'", self.settings_path)
         self._write_settings("foo = 'new value'\nhello = 'world'",
                              self.user_settings_path)
-        initialize_settings('user settings', self.settings_path, 'user.cfg')
+        initialize_settings(self.settings_path, 'user.cfg')
         self._check_content(
             {'foo': 'new value', 'hello': 'world',
              SettingsMigrator.SETTINGS_VERSION:
@@ -319,7 +317,7 @@ class TestInitializeSettings(TestSettingsHelper):
                              self.settings_path)
         self._write_settings("invalid = invalid", self.user_settings_path)
         self.assertRaises(
-            ConfigurationError, initialize_settings, 'user settings',
+            ConfigurationError, initialize_settings,
             self.settings_path, 'user.cfg')
 
     def test_initialize_settings_replaces_corrupted_settings_with_defaults(
@@ -328,7 +326,7 @@ class TestInitializeSettings(TestSettingsHelper):
         self._write_settings("dlskajldsjjw2018032")
         defaults = self._read_file(self.settings_path)
         settings = self._read_file(initialize_settings(
-            'user settings', self.settings_path, 'user.cfg'))
+            self.settings_path, 'user.cfg'))
         self.assertEqual(defaults, settings)
 
     def _read_file(self, path):


### PR DESCRIPTION
This means mostly removing from __future__ import with_statement.
Even previous versions have not been fully 2.5 compatible, so this
is just removing dead code.