### PR TITLE
Set min height to tag box

### DIFF
--- a/src/robotide/editor/tags.py
+++ b/src/robotide/editor/tags.py
@@ -29,6 +29,7 @@ class TagsDisplay(wx.Panel):
         wx.Panel.__init__(self, parent, wx.ID_ANY)
         self._controller = controller
         self._sizer = HorizontalFlowSizer()
+        self._sizer.SetMinSize((0, 20))
         self._tag_boxes = []
         self.SetSizer(self._sizer)
 


### PR DESCRIPTION
This is required in OSX, otherwise the tag box height is calculated wrong
initially.

