### PR TITLE
Fix UnicodeEncodeErrors in `str.format()` usages

### DIFF
--- a/src/robotide/controller/tags.py
+++ b/src/robotide/controller/tags.py
@@ -54,7 +54,7 @@ class ForcedTag(Tag):
 
     @property
     def tooltip(self):
-        return 'Force tag from suite {0}'.format(
+        return u'Force tag from suite {0}'.format(
             self.controller.datafile_controller.name)
 
 
@@ -62,5 +62,5 @@ class DefaultTag(Tag):
 
     @property
     def tooltip(self):
-        return 'Default tag from suite {0}'.format(
+        return u'Default tag from suite {0}'.format(
             self.controller.datafile_controller.name)

--- a/src/robotide/namespace/namespace.py
+++ b/src/robotide/namespace/namespace.py
@@ -56,7 +56,7 @@ class Namespace(object):
             if path not in sys.path:
                 normalized = path.replace('/', os.sep)
                 sys.path.insert(0, normalized)
-                RideLogMessage("Inserted '{0}' to sys.path."
+                RideLogMessage(u'Inserted \'{0}\' to sys.path.'
                                .format(normalized)).publish()
 
     def _setting_changed(self, message):
@@ -340,7 +340,7 @@ class _VariableStash(object):
         for name, value in self._vars.store.data.items():
             source = self._sources[name]
             prefix = self._get_prefix(value)
-            name = '{0}{{{1}}}'.format(prefix, name)
+            name = u'{0}{{{1}}}'.format(prefix, name)
             if source == self.ARGUMENT_SOURCE:
                 yield ArgumentInfo(name, value)
             else:

--- a/src/robotide/spec/librarymanager.py
+++ b/src/robotide/spec/librarymanager.py
@@ -129,7 +129,7 @@ class LibraryManager(Thread):
         try:
             return result_queue.get(timeout=5)
         except Queue.Empty as e:
-            RideLogMessage('Failed to read keywords from library db: {}'
+            RideLogMessage(u'Failed to read keywords from library db: {}'
                            .format(unicode(e))).publish()
             return []
 

--- a/utest/namespace/test_namespace.py
+++ b/utest/namespace/test_namespace.py
@@ -69,6 +69,8 @@ def _add_variable_table(tcf):
     tcf.variable_table.add(UNRESOLVABLE_VARIABLE, UNKNOWN_VARIABLE)
     tcf.variable_table.add(COLLIDING_CONSTANT, 'collision')
     tcf.variable_table.add('&{dict var}', {'key': 'value'})
+    tcf.variable_table.add(u'${I <3 Unicode and \xe4iti}', u'123 \xe7')
+
 
 
 def _add_keyword_table(tcf):


### PR DESCRIPTION
It seems that str.format() breaks with UnicodeEncodeError if
str is ascii literal and format arguments are unciode. Fix all usages
of `format` to prevent runtime errors