### PR TITLE
fix view all tags(F7) doesn't work on windows #1526

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -22,3 +22,4 @@ Kevin Ormbrek
 Timothy Alexander
 @tuds
 @goodwillcoding
+@synsun

--- a/src/robotide/ui/tagdialogs.py
+++ b/src/robotide/ui/tagdialogs.py
@@ -147,7 +147,7 @@ class ViewAllTagsDialog(wx.Frame):
                     self._unique_tags[tag_name].append(test)
                     self._tagit[tag_name].append(tag)
                 else:
-                    self._unique_tags.set(tag_name, [test])
+                    self._unique_tags[tag_name] = [test]
                     self._tagit[tag_name] = [tag]
 
         self.total_test_cases = len(self._test_cases)


### PR DESCRIPTION
I don't know how to work 'view all tags' with execute '_search_for_tags()' in tagdialogs.py without 'set()' in 'normalizing.py'.

But after I noticed that function replaced to '__setitem__' I could fix this problem.