### PR TITLE
Fix #1548

### DIFF
--- a/src/robotide/log/log.py
+++ b/src/robotide/log/log.py
@@ -56,7 +56,7 @@ class LogPlugin(Plugin):
             try:
                 os.remove(fname)
             except OSError or IOError as e:
-                print >> sys.stderr, e
+                sys.stderr.write("{}".format(e))
                 pass
 
     @property

--- a/src/robotide/log/log.py
+++ b/src/robotide/log/log.py
@@ -18,6 +18,7 @@ import tempfile
 import uuid
 import atexit
 import glob
+import sys
 
 from robotide.pluginapi import Plugin, ActionInfo, RideLog
 from robotide import widgets
@@ -51,10 +52,11 @@ class LogPlugin(Plugin):
 
     def _remove_old_log_files(self):
         for fname in glob.glob(
-                os.path.join(tempfile.gettempdir(), '*ride.log')):
+                os.path.join(tempfile.gettempdir(), '*-ride.log')):
             try:
                 os.remove(fname)
-            except IOError:
+            except OSError or IOError as e:
+                print >> sys.stderr, e
                 pass
 
     @property


### PR DESCRIPTION
Corrects outputting of the exception when failed to delete a locked file, but allows to start RIDE. Tested in Windows.