### PR TITLE
Make test runner console font less ugly

### DIFF
--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -639,7 +639,7 @@ class TestRunnerPlugin(Plugin):
         out.SetMarginWidth(3,0)
 
     def _create_font(self):
-        font=wx.SystemSettings.GetFont(wx.SYS_SYSTEM_FIXED_FONT)
+        font=wx.SystemSettings.GetFont(wx.SYS_ANSI_FIXED_FONT)
         if not font.IsFixedWidth():
             # fixed width fonts are typically a little bigger than their variable width
             # peers so subtract one from the point size.


### PR DESCRIPTION
Changed font designation from SYS_SYSTEM_FIXED_FONT to SYS_ANSI_FIXED_FONT. SYS_SYSTEM_FIXED_FONT creates a truly bugly experience. SYS_ANSI_FIXED_FONT isn't perfect, but it's a bit more tolerable.