### PR TITLE
Enhancement #1527 sort tag list

### DIFF
--- a/src/robotide/ui/tagdialogs.py
+++ b/src/robotide/ui/tagdialogs.py
@@ -32,12 +32,13 @@ class ViewAllTagsDialog(wx.Frame, listmix.ColumnSorterMixin):
         self.frame = frame
         self.tree = self.frame.tree
         self._controller = controller
-        self.itemDataMap = dict()
         self._results = utils.NormalizedDict()
         self.selected_tests = list()
         self.tagged_test_cases = list()
         self.unique_tags = 0
         self.total_test_cases = 0
+        self.itemDataMap = dict()
+        self.sort_state = (1, 0)
         self._index = -1
         self._build_ui()
         self._make_bindings()
@@ -98,6 +99,7 @@ class ViewAllTagsDialog(wx.Frame, listmix.ColumnSorterMixin):
         self.Bind(wx.EVT_CLOSE, self._close_dialog)
         self.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnTagSelected)
         self._tags_list.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self.OnRightClick)
+        self._tags_list.Bind(wx.EVT_LIST_COL_CLICK, self.OnColClick)
 
     def _execute(self):
         self._clear_search_results()
@@ -119,6 +121,7 @@ class ViewAllTagsDialog(wx.Frame, listmix.ColumnSorterMixin):
         self._tags_list.setResizeColumn(1)
         self.tagged_test_cases = list(set(self.tagged_test_cases))
         self.update_footer()
+        self.SortListItems(self.sort_state[0], self.sort_state[1])
 
     def update_footer(self):
         footer_string = "Total tests %d, Tests with tags %d, Unique tags %d, Currently selected tests %d" % \
@@ -165,6 +168,7 @@ class ViewAllTagsDialog(wx.Frame, listmix.ColumnSorterMixin):
         return self._tags_list
 
     def OnColClick(self, event):
+        self.sort_state = self.GetSortState()
         event.Skip()
 
     def _add_checked_tags_into_list(self):

--- a/src/robotide/ui/tagdialogs.py
+++ b/src/robotide/ui/tagdialogs.py
@@ -23,7 +23,7 @@ from robotide.ui.treenodehandlers import ResourceRootHandler, \
 from robotide.widgets import ButtonWithHandler, PopupMenuItems
 
 
-class ViewAllTagsDialog(wx.Frame):
+class ViewAllTagsDialog(wx.Frame, listmix.ColumnSorterMixin):
 
     def __init__(self, controller, frame):
         style = wx.SYSTEM_MENU | wx.CAPTION | wx.CLOSE_BOX | wx.CLIP_CHILDREN | \
@@ -32,6 +32,7 @@ class ViewAllTagsDialog(wx.Frame):
         self.frame = frame
         self.tree = self.frame.tree
         self._controller = controller
+        self.itemDataMap = dict()
         self._results = utils.NormalizedDict()
         self.selected_tests = list()
         self.tagged_test_cases = list()
@@ -40,6 +41,10 @@ class ViewAllTagsDialog(wx.Frame):
         self._index = -1
         self._build_ui()
         self._make_bindings()
+
+        # init ColumnSorterMixin at the end because it calls self.GetListCtrl and
+        # therefore self._tags_list has to be declared
+        listmix.ColumnSorterMixin.__init__(self, 2)
 
     def _build_ui(self):
         self.SetSize((500, 400))
@@ -107,6 +112,8 @@ class ViewAllTagsDialog(wx.Frame):
                 self.unique_tags, unicode(tag_name))
             self.tagged_test_cases += tests
             self._tags_list.SetStringItem(self.unique_tags, 1, str(len(tests)))
+            self._tags_list.SetItemData(self.unique_tags, self.unique_tags)
+            self.itemDataMap[self.unique_tags] = (tag_name, len(tests))
             self.unique_tags += 1
         self._tags_list.SetColumnWidth(1, wx.LIST_AUTOSIZE_USEHEADER)
         self._tags_list.setResizeColumn(1)

--- a/src/robotide/ui/tagdialogs.py
+++ b/src/robotide/ui/tagdialogs.py
@@ -115,7 +115,8 @@ class ViewAllTagsDialog(wx.Frame, listmix.ColumnSorterMixin):
             self.tagged_test_cases += tests
             self._tags_list.SetStringItem(self.unique_tags, 1, str(len(tests)))
             self._tags_list.SetItemData(self.unique_tags, self.unique_tags)
-            self.itemDataMap[self.unique_tags] = (tag_name, len(tests))
+            # make tag_name lowercase for the sorting algorithm only
+            self.itemDataMap[self.unique_tags] = (tag_name.lower(), len(tests))
             self.unique_tags += 1
         self._tags_list.SetColumnWidth(1, wx.LIST_AUTOSIZE_USEHEADER)
         self._tags_list.setResizeColumn(1)


### PR DESCRIPTION
Implemented enhancement #1527: "Tag list sort by name in View all tags".

 Added the `mixin wx.lib.mixins.listctrl.ColumnSorterMixin` that is implemented by `robotide.ui.tagdialogs.ViewAllTagsDialog`. This includes the creation of a new field `itemDataMap` and `sort_state` as well as a call to `self._tags_list.SetItemData` in `self._execute`.

The second commit ensures that the sort order is kept on refresh.