### PR TITLE
Fixing bug #1529 "Using '(De)select all tests' option will expand all…

### DIFF
--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -651,7 +651,7 @@ class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl,
         for child in item.GetChildren():
             self._for_all_tests(child, func)
 
-        if is_item_expanded is False:
+        if not is_item_expanded:
             self.Collapse(item)
 
     def _for_all_drawn_tests(self, item, func):

--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -639,13 +639,20 @@ class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl,
         if not self.HasAGWFlag(customtreectrl.TR_HIDE_ROOT) or item != self.GetRootItem():
             if isinstance(item.GetData(), ResourceRootHandler or ResourceFileHandler):
                 return
-            self.Expand(item)
+
+            is_item_expanded = self.IsExpanded(item)
+            if is_item_expanded is False:
+                self.Expand(item)
             if self._is_test_node(item):
                 func(item)
             if not self.IsExpanded(item):
                 return
+
         for child in item.GetChildren():
             self._for_all_tests(child, func)
+
+        if is_item_expanded is False:
+            self.Collapse(item)
 
     def _for_all_drawn_tests(self, item, func):
         if self._is_test_node(item):


### PR DESCRIPTION
… nodes" by simply remembering the state of the element when it is walked over and restore it in the end.