### PR TITLE
Bugfix #1416: test case checkbox cleard upon save in textedit

### DIFF
--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -176,6 +176,9 @@ class TestSelectionController(object):
     def is_empty(self):
         return not bool(self._tests)
 
+    def is_test_selected(self, test):
+        return test.longname in self._tests.keys()
+
     def clear_all(self, message=None):
         self._tests = {}
         self.send_selection_changed_message()
@@ -187,7 +190,7 @@ class TestSelectionController(object):
     def select(self, test, selected=True):
         if selected:
             self._tests[test.longname] = test
-        elif test.longname in self._tests:
+        elif self.is_test_selected(test):
             del self._tests[test.longname]
         self.send_selection_changed_message()
 

--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -305,13 +305,16 @@ class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl,
         if isinstance(controller, ResourceFileController):
             if not controller.is_used():
                 self.SetItemTextColour(node, wx.ColorRGB(0xA9A9A9))
-        self.SetPyData(node, handler_class(controller, self, node, self._controller.settings))
+        action_handler = handler_class(
+            controller, self, node, self._controller.settings)
+        self.SetPyData(node, action_handler)
 
-        # if we have a TestCase node we have to make sure that we retain the checked state
-        if (handler_class == TestCaseHandler and self._checkboxes_for_tests) and \
-                self._test_selection_controller.is_test_selected(controller):
+        # if we have a TestCase node we have to make sure that
+        # we retain the checked state
+        if (handler_class == TestCaseHandler and self._checkboxes_for_tests) \
+                and self._test_selection_controller.is_test_selected(
+                    controller):
             self.CheckItem(node, True)
-
         if controller.is_excluded():
             self._set_item_excluded(node)
         return node

--- a/utest/controller/ui/test_treecontroller.py
+++ b/utest/controller/ui/test_treecontroller.py
@@ -131,6 +131,13 @@ class TestTestSelectionController(unittest.TestCase):
         self._tsc.select(self._create_test(), False)
         self.assertTrue(self._tsc.is_empty())
 
+    def test_is_test_selected(self):
+        test = self._create_test()
+        self.assertFalse(self._tsc.is_test_selected(test))
+
+        self._tsc.select(test)
+        self.assertTrue(self._tsc.is_test_selected(test))
+
     def test_adding_tag_to_selected_tests(self):
         tests = [self._create_test('test%d' % i) for i in range(10)]
         for t in tests:


### PR DESCRIPTION
Fixing #1416 by removing call to `TreeSelectionController.unselect_all` after files change. As a consequence implementing a call to deselect nodes that are removed and thus maintaining a consistent model of selected tests. As far as I am aware of, no undo operation is provided for removed TestCases (at least none working on my local installation) and therefore did not need to be considered. A simple unit test is added to ensure new method in `TreeSelectionController` works as expected.

Also merged latest PEP8 related changes from master.