### PR TITLE
Modernized setup, relax wx verification, new --version option, post install Desktop shortcut

### DIFF
--- a/ride_postinstall.py
+++ b/ride_postinstall.py
@@ -1,31 +1,158 @@
+#!/usr/bin/env python
+# encoding=utf-8
+
 import sys
 from os.path import exists, join
-from Tkinter import Tk
-from tkMessageBox import askyesno
+
+__doc__ = """
+Usage: ride_postinstall.py <-install|-remove>
+""".strip()
+# TODO: Add -remove, to remove desktop shortcut
 
 
 def verify_install():
     try:
-        import wxversion
-    except ImportError:
-        print "No wxPython installation detected!"
-        print ""
-        print "Please ensure that you have wxPython installed before running RIDE."
-        print "You can obtain wxPython 2.8.12.1 from http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/"
+        from wx import version
+    except ImportError as err:
+        print("No wxPython installation detected!")
+        print("")
+        print("Please ensure that you have wxPython installed before running \
+RIDE.")
+        print("You can obtain wxPython 2.8.12.1 from \
+http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/")
+        sys.exit(1)
     else:
-        print "Installation successful."
+        print("Installation successful.")
 
 
-def create_desktop_shortcut():
-    Tk().withdraw()
-    link = join(get_special_folder_path("CSIDL_DESKTOPDIRECTORY"), 'RIDE.lnk')
-    icon = join(sys.prefix, 'Lib', 'site-packages', 'robotide', 'widgets', 'robot.ico')
-    if exists(link) or askyesno('Setup', 'Create desktop shortcut?'):
-        create_shortcut('pythonw', "Robot Framework testdata editor", link,
-                        '-c "from robotide import main; main()"', '', icon)
-        file_created(link)
+def _askyesno(title, message):
+    import wx
+    _ = wx.App()
+    parent = wx.Frame(None, size=(0, 0))
+    parent.CenterOnScreen()
+    dlg = wx.MessageDialog(parent, message, title, wx.YES_NO |
+                           wx.ICON_QUESTION)
+    result = dlg.ShowModal() == wx.ID_YES
+    dlg.Destroy()
+    return result
 
 
-if sys.argv[1] == '-install':
-    verify_install()
-    create_desktop_shortcut()
+def _askdirectory(title, initialdir):
+    import wx
+    _ = wx.App()
+    parent = wx.Frame(None, size=(0, 0))
+    dlg = wx.DirDialog(parent, title, initialdir, style=wx.DD_DIR_MUST_EXIST)
+    if dlg.ShowModal() == wx.ID_OK:
+        result = dlg.GetPath()
+    else:
+        result = None
+    dlg.Destroy()
+    return result
+
+
+def _create_desktop_shortcut_linux():
+    import os
+    import subprocess
+    import pwd
+    DEFAULT_LANGUAGE = os.environ.get('LANG', '').split(':')
+    # TODO: Add more languages
+    desktop = {"de": "Desktop", "en": "Desktop", "es": "Escritorio",
+               "fi": r"Työpötä", "fr": "Bureau", "it": "Scrivania",
+               "pt": r"Área de Trabalho"}
+    try:
+        ndesktop = desktop[DEFAULT_LANGUAGE[0][:2]]
+        user = subprocess.check_output(['logname']).strip()
+        link = os.path.join("/home", user, ndesktop, "RIDE.desktop")
+    except KeyError as kerr:
+        directory = _askdirectory(title="Locate Desktop Directory",
+                                  initialdir=os.path.join(os.path.expanduser(
+                                                          '~')))
+        if not directory:
+            sys.exit("Desktop shortcut creation aborted!")
+        else:
+            link = join(directory, "RIDE.desktop")
+    if exists(link) or _askyesno("Setup", "Create desktop shortcut?"):
+        roboticon = "/usr/lib/python{0}/site-packages/robotide/widgets/robot.p\
+ng".format(sys.version[:3])
+        with open(link, "w+") as shortcut:
+            shortcut.write("#!/usr/bin/env xdg-open\n[Desktop Entry]\nExec=\
+ride.py\nComment=A Robot Framework IDE\nGenericName=RIDE\n")
+            shortcut.write("Icon={0}\n".format(roboticon))
+            shortcut.write("Name=RIDE\nStartupNotify=true\nTerminal=false\nTyp\
+e=Application\nX-KDE-SubstituteUID=false\n")
+            uid = pwd.getpwnam(user).pw_uid
+            os.chown(link, uid, -1)  # groupid == -1 means keep unchanged
+
+
+def _create_desktop_shortcut_mac():
+    import os
+    import subprocess
+    import pwd
+    user = subprocess.check_output(['logname']).strip()
+    link = os.path.join("/Users", user, "Desktop", "RIDE")
+    if exists(link) or _askyesno("Setup", "Create desktop shortcut?"):
+        roboticon = "/Library/Python/{0}/site-packages/robotide/widgets/robot.p\
+ng".format(sys.version[:3])  # TODO: Find a way to change shortcut icon
+        with open(link, "w+") as shortcut:
+            shortcut.write("#!/bin/sh\n/usr/local/bin/ride.py $* &\n")
+        uid = pwd.getpwnam(user).pw_uid
+        os.chown(link, uid, -1)  # groupid == -1 means keep unchanged
+        os.chmod(link, 0744)
+
+
+def _create_desktop_shortcut_windows():
+    # Dependency of http://sourceforge.net/projects/pywin32/
+    import os
+    import sys
+    from win32com.shell import shell, shellcon
+    desktop = shell.SHGetFolderPath(0, shellcon.CSIDL_DESKTOP, None, 0)
+    link = os.path.join(desktop, 'RIDE.lnk')
+    icon = os.path.join(sys.prefix, 'Lib', 'site-packages', 'robotide',
+                        'widgets', 'robot.ico')
+    if not exists(link):
+        from Tkinter import Tk
+        from tkMessageBox import askyesno
+        Tk().withdraw()
+        if not askyesno('Setup', 'Create desktop shortcut?'):
+            sys.exit("Users can create a Desktop shortcut to RIDE with:\
+\nride_postinstall.py -install\n")
+        import pythoncom
+        shortcut = pythoncom.CoCreateInstance(shell.CLSID_ShellLink, None,
+                                              pythoncom.CLSCTX_INPROC_SERVER,
+                                              shell.IID_IShellLink)
+        command_args = " -c \"from robotide import main; main()\""
+        shortcut.SetPath("pythonw.exe")  # sys.executable
+        shortcut.SetArguments(command_args)
+        shortcut.SetDescription("Robot Framework testdata editor")
+        shortcut.SetIconLocation(icon, 0)
+        persist_file = shortcut.QueryInterface(pythoncom.IID_IPersistFile)
+        persist_file.Save(link, 0)
+        if __name__ != '__main__':
+            file_created(link)  # Only in Windows installer. How to detect?
+
+
+def create_desktop_shortcut(platform):
+    if platform.startswith("linux"):
+        _create_desktop_shortcut_linux()
+    elif platform.startswith("darwin"):
+        _create_desktop_shortcut_mac()
+    elif platform.startswith("win"):
+        _create_desktop_shortcut_windows()
+    else:
+        sys.exit("Unknown platform {0}: Failed to create desktop shortcut.".
+                 format(platform))
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == '-install':
+        platform = sys.platform.lower()
+        if not platform.startswith("win"):
+            verify_install()
+        create_desktop_shortcut(platform)
+    else:
+        print(__doc__)
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/ride_postinstall.py
+++ b/ride_postinstall.py
@@ -62,7 +62,8 @@ def _create_desktop_shortcut_linux():
     try:
         ndesktop = desktop[DEFAULT_LANGUAGE[0][:2]]
         user = subprocess.check_output(['logname']).strip()
-        link = os.path.join("/home", user, ndesktop, "RIDE.desktop")
+        directory = os.path.join("/home", user, ndesktop)
+        link = os.path.join(directory, "RIDE.desktop")
     except KeyError as kerr:
         directory = _askdirectory(title="Locate Desktop Directory",
                                   initialdir=os.path.join(os.path.expanduser(
@@ -71,6 +72,9 @@ def _create_desktop_shortcut_linux():
             sys.exit("Desktop shortcut creation aborted!")
         else:
             link = join(directory, "RIDE.desktop")
+    defaultdir = os.path.join(os.path.expanduser('~'), "Desktop")
+    if exists(defaultdir) and not exists(directory):
+       link = join(defaultdir, "RIDE.desktop")
     if exists(link) or _askyesno("Setup", "Create desktop shortcut?"):
         roboticon = "/usr/lib/python{0}/site-packages/robotide/widgets/robot.p\
 ng".format(sys.version[:3])

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,18 @@
-import os
-from os.path import abspath, join, dirname, isdir, isfile
-from distutils.core import setup
+#!/usr/bin/env python
 
+import sys
+from os.path import abspath, join, dirname
 
-def find_packages(where):
-    def is_package(path):
-        return isdir(path) and isfile(join(path, '__init__.py'))
-    pkgs = []
-    for dirpath, dirs, _ in os.walk(where):
-        for dir_name in dirs:
-            pkg_path = join(dirpath, dir_name)
-            if is_package(pkg_path):
-                pkgs.append('.'.join((pkg_path.split(os.sep)[1:])))
-    return pkgs
+sys.path.append(join(dirname(__file__), 'src'))
+from ez_setup import use_setuptools
+use_setuptools()
+from setuptools import setup, find_packages
 
 ROOT_DIR = dirname(abspath(__file__))
 SOURCE_DIR = 'src'
 
-execfile(join(ROOT_DIR, 'src', 'robotide', 'version.py'))
+version_file = join(ROOT_DIR, 'src', 'robotide', 'version.py')
+exec(compile(open(version_file).read(), version_file, 'exec'))
 
 package_data = {
     'robotide.preferences': ['settings.cfg'],
@@ -40,6 +35,17 @@ Programming Language :: Python
 Topic :: Software Development :: Testing
 """.strip().splitlines()
 
+# This solution is found at http://stackoverflow.com/a/26490820/5889853
+from setuptools.command.install import install
+import os
+
+
+class CustomInstallCommand(install):
+    """Customized setuptools install command - prints a friendly greeting."""
+    def run(self):
+        install.run(self)
+        os.system("ride_postinstall.py -install")
+
 setup(
     name='robotframework-ride',
     version=VERSION,
@@ -53,6 +59,7 @@ setup(
     author_email='robotframework@gmail.com',
     url='https://github.com/robotframework/RIDE/',
     download_url='https://pypi.python.org/pypi/robotframework-ride',
+    py_modules=['ez_setup'],
     package_dir={'': SOURCE_DIR},
     packages=find_packages(SOURCE_DIR),
     package_data=package_data,
@@ -60,5 +67,6 @@ setup(
     # Always install everything, since we may be switching between versions
     options={'install': {'force': True}},
     scripts=['src/bin/ride.py', 'ride_postinstall.py'],
+    cmdclass={'install': CustomInstallCommand},
     requires=['Pygments']
 )

--- a/src/bin/ride.py
+++ b/src/bin/ride.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 #  Copyright 2008-2015 Nokia Solutions and Networks
 #  

--- a/src/ez_setup.py
+++ b/src/ez_setup.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python
+
+"""
+Setuptools bootstrapping installer.
+
+Run this script to install or upgrade setuptools.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import zipfile
+import optparse
+import subprocess
+import platform
+import textwrap
+import contextlib
+import json
+import codecs
+
+from distutils import log
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+try:
+    from site import USER_SITE
+except ImportError:
+    USER_SITE = None
+
+LATEST = object()
+DEFAULT_VERSION = LATEST
+DEFAULT_URL = "https://pypi.python.org/packages/source/s/setuptools/"
+DEFAULT_SAVE_DIR = os.curdir
+
+
+def _python_cmd(*args):
+    """
+    Execute a command.
+
+    Return True if the command succeeded.
+    """
+    args = (sys.executable,) + args
+    return subprocess.call(args) == 0
+
+
+def _install(archive_filename, install_args=()):
+    """Install Setuptools."""
+    with archive_context(archive_filename):
+        # installing
+        log.warn('Installing Setuptools')
+        if not _python_cmd('setup.py', 'install', *install_args):
+            log.warn('Something went wrong during the installation.')
+            log.warn('See the error message above.')
+            # exitcode will be 2
+            return 2
+
+
+def _build_egg(egg, archive_filename, to_dir):
+    """Build Setuptools egg."""
+    with archive_context(archive_filename):
+        # building an egg
+        log.warn('Building a Setuptools egg in %s', to_dir)
+        _python_cmd('setup.py', '-q', 'bdist_egg', '--dist-dir', to_dir)
+    # returning the result
+    log.warn(egg)
+    if not os.path.exists(egg):
+        raise IOError('Could not build the egg.')
+
+
+class ContextualZipFile(zipfile.ZipFile):
+
+    """Supplement ZipFile class to support context manager for Python 2.6."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def __new__(cls, *args, **kwargs):
+        """Construct a ZipFile or ContextualZipFile as appropriate."""
+        if hasattr(zipfile.ZipFile, '__exit__'):
+            return zipfile.ZipFile(*args, **kwargs)
+        return super(ContextualZipFile, cls).__new__(cls)
+
+
+@contextlib.contextmanager
+def archive_context(filename):
+    """
+    Unzip filename to a temporary directory, set to the cwd.
+
+    The unzipped target is cleaned up after.
+    """
+    tmpdir = tempfile.mkdtemp()
+    log.warn('Extracting in %s', tmpdir)
+    old_wd = os.getcwd()
+    try:
+        os.chdir(tmpdir)
+        with ContextualZipFile(filename) as archive:
+            archive.extractall()
+
+        # going in the directory
+        subdir = os.path.join(tmpdir, os.listdir(tmpdir)[0])
+        os.chdir(subdir)
+        log.warn('Now working in %s', subdir)
+        yield
+
+    finally:
+        os.chdir(old_wd)
+        shutil.rmtree(tmpdir)
+
+
+def _do_download(version, download_base, to_dir, download_delay):
+    """Download Setuptools."""
+    egg = os.path.join(to_dir, 'setuptools-%s-py%d.%d.egg'
+                       % (version, sys.version_info[0], sys.version_info[1]))
+    if not os.path.exists(egg):
+        archive = download_setuptools(version, download_base,
+                                      to_dir, download_delay)
+        _build_egg(egg, archive, to_dir)
+    sys.path.insert(0, egg)
+
+    # Remove previously-imported pkg_resources if present (see
+    # https://bitbucket.org/pypa/setuptools/pull-request/7/ for details).
+    if 'pkg_resources' in sys.modules:
+        _unload_pkg_resources()
+
+    import setuptools
+    setuptools.bootstrap_install_from = egg
+
+
+def use_setuptools(
+        version=DEFAULT_VERSION, download_base=DEFAULT_URL,
+        to_dir=DEFAULT_SAVE_DIR, download_delay=15):
+    """
+    Ensure that a setuptools version is installed.
+
+    Return None. Raise SystemExit if the requested version
+    or later cannot be installed.
+    """
+    version = _resolve_version(version)
+    to_dir = os.path.abspath(to_dir)
+
+    # prior to importing, capture the module state for
+    # representative modules.
+    rep_modules = 'pkg_resources', 'setuptools'
+    imported = set(sys.modules).intersection(rep_modules)
+
+    try:
+        import pkg_resources
+        pkg_resources.require("setuptools>=" + version)
+        # a suitable version is already installed
+        return
+    except ImportError:
+        # pkg_resources not available; setuptools is not installed; download
+        pass
+    except pkg_resources.DistributionNotFound:
+        # no version of setuptools was found; allow download
+        pass
+    except pkg_resources.VersionConflict as VC_err:
+        if imported:
+            _conflict_bail(VC_err, version)
+
+        # otherwise, unload pkg_resources to allow the downloaded version to
+        #  take precedence.
+        del pkg_resources
+        _unload_pkg_resources()
+
+    return _do_download(version, download_base, to_dir, download_delay)
+
+
+def _conflict_bail(VC_err, version):
+    """
+    Setuptools was imported prior to invocation, so it is
+    unsafe to unload it. Bail out.
+    """
+    conflict_tmpl = textwrap.dedent("""
+        The required version of setuptools (>={version}) is not available,
+        and can't be installed while this script is running. Please
+        install a more recent version first, using
+        'easy_install -U setuptools'.
+
+        (Currently using {VC_err.args[0]!r})
+        """)
+    msg = conflict_tmpl.format(**locals())
+    sys.stderr.write(msg)
+    sys.exit(2)
+
+
+def _unload_pkg_resources():
+    del_modules = [
+        name for name in sys.modules
+        if name.startswith('pkg_resources')
+    ]
+    for mod_name in del_modules:
+        del sys.modules[mod_name]
+
+
+def _clean_check(cmd, target):
+    """
+    Run the command to download target.
+
+    If the command fails, clean up before re-raising the error.
+    """
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError:
+        if os.access(target, os.F_OK):
+            os.unlink(target)
+        raise
+
+
+def download_file_powershell(url, target):
+    """
+    Download the file at url to target using Powershell.
+
+    Powershell will validate trust.
+    Raise an exception if the command cannot complete.
+    """
+    target = os.path.abspath(target)
+    ps_cmd = (
+        "[System.Net.WebRequest]::DefaultWebProxy.Credentials = "
+        "[System.Net.CredentialCache]::DefaultCredentials; "
+        '(new-object System.Net.WebClient).DownloadFile("%(url)s", "%(target)s\
+")'
+        % locals()
+    )
+    cmd = [
+        'powershell',
+        '-Command',
+        ps_cmd,
+    ]
+    _clean_check(cmd, target)
+
+
+def has_powershell():
+    """Determine if Powershell is available."""
+    if platform.system() != 'Windows':
+        return False
+    cmd = ['powershell', '-Command', 'echo test']
+    with open(os.path.devnull, 'wb') as devnull:
+        try:
+            subprocess.check_call(cmd, stdout=devnull, stderr=devnull)
+        except Exception:
+            return False
+    return True
+download_file_powershell.viable = has_powershell
+
+
+def download_file_curl(url, target):
+    cmd = ['curl', url, '--silent', '--output', target]
+    _clean_check(cmd, target)
+
+
+def has_curl():
+    cmd = ['curl', '--version']
+    with open(os.path.devnull, 'wb') as devnull:
+        try:
+            subprocess.check_call(cmd, stdout=devnull, stderr=devnull)
+        except Exception:
+            return False
+    return True
+download_file_curl.viable = has_curl
+
+
+def download_file_wget(url, target):
+    cmd = ['wget', url, '--quiet', '--output-document', target]
+    _clean_check(cmd, target)
+
+
+def has_wget():
+    cmd = ['wget', '--version']
+    with open(os.path.devnull, 'wb') as devnull:
+        try:
+            subprocess.check_call(cmd, stdout=devnull, stderr=devnull)
+        except Exception:
+            return False
+    return True
+download_file_wget.viable = has_wget
+
+
+def download_file_insecure(url, target):
+    """Use Python to download the file, without connection authentication."""
+    src = urlopen(url)
+    try:
+        # Read all the data in one block.
+        data = src.read()
+    finally:
+        src.close()
+
+    # Write all the data in one block to avoid creating a partial file.
+    with open(target, "wb") as dst:
+        dst.write(data)
+download_file_insecure.viable = lambda: True
+
+
+def get_best_downloader():
+    downloaders = (
+        download_file_powershell,
+        download_file_curl,
+        download_file_wget,
+        download_file_insecure,
+    )
+    viable_downloaders = (dl for dl in downloaders if dl.viable())
+    return next(viable_downloaders, None)
+
+
+def download_setuptools(
+        version=DEFAULT_VERSION, download_base=DEFAULT_URL,
+        to_dir=DEFAULT_SAVE_DIR, delay=15,
+        downloader_factory=get_best_downloader):
+    """
+    Download setuptools from a specified location and return its filename.
+
+    `version` should be a valid setuptools version number that is available
+    as an sdist for download under the `download_base` URL (which should end
+    with a '/'). `to_dir` is the directory where the egg will be downloaded.
+    `delay` is the number of seconds to pause before an actual download
+    attempt.
+
+    ``downloader_factory`` should be a function taking no arguments and
+    returning a function for downloading a URL to a target.
+    """
+    version = _resolve_version(version)
+    # making sure we use the absolute path
+    to_dir = os.path.abspath(to_dir)
+    zip_name = "setuptools-%s.zip" % version
+    url = download_base + zip_name
+    saveto = os.path.join(to_dir, zip_name)
+    if not os.path.exists(saveto):  # Avoid repeated downloads
+        log.warn("Downloading %s", url)
+        downloader = downloader_factory()
+        downloader(url, saveto)
+    return os.path.realpath(saveto)
+
+
+def _resolve_version(version):
+    """
+    Resolve LATEST version
+    """
+    if version is not LATEST:
+        return version
+
+    resp = urlopen('https://pypi.python.org/pypi/setuptools/json')
+    with contextlib.closing(resp):
+        try:
+            charset = resp.info().get_content_charset()
+        except Exception:
+            # Python 2 compat; assume UTF-8
+            charset = 'UTF-8'
+        reader = codecs.getreader(charset)
+        doc = json.load(reader(resp))
+
+    return str(doc['info']['version'])
+
+
+def _build_install_args(options):
+    """
+    Build the arguments to 'python setup.py install' on the setuptools package.
+
+    Returns list of command line arguments.
+    """
+    return ['--user'] if options.user_install else []
+
+
+def _parse_args():
+    """Parse the command line for options."""
+    parser = optparse.OptionParser()
+    parser.add_option(
+        '--user', dest='user_install', action='store_true', default=False,
+        help='install in user site package (requires Python 2.6 or later)')
+    parser.add_option(
+        '--download-base', dest='download_base', metavar="URL",
+        default=DEFAULT_URL,
+        help='alternative URL from where to download the setuptools package')
+    parser.add_option(
+        '--insecure', dest='downloader_factory', action='store_const',
+        const=lambda: download_file_insecure, default=get_best_downloader,
+        help='Use internal, non-validating downloader'
+    )
+    parser.add_option(
+        '--version', help="Specify which version to download",
+        default=DEFAULT_VERSION,
+    )
+    parser.add_option(
+        '--to-dir',
+        help="Directory to save (and re-use) package",
+        default=DEFAULT_SAVE_DIR,
+    )
+    options, args = parser.parse_args()
+    # positional arguments are ignored
+    return options
+
+
+def _download_args(options):
+    """Return args for download_setuptools function from cmdline args."""
+    return dict(
+        version=options.version,
+        download_base=options.download_base,
+        downloader_factory=options.downloader_factory,
+        to_dir=options.to_dir,
+    )
+
+
+def main():
+    """Install or upgrade setuptools and EasyInstall."""
+    options = _parse_args()
+    archive = download_setuptools(**_download_args(options))
+    return _install(archive, _build_install_args(options))
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -14,7 +14,7 @@
 
 """RIDE -- Robot Framework test data editor
 
-Usage: ride.py [--noupdatecheck] [--debugconsole] [inpath]
+Usage: ride.py [--noupdatecheck] [--debugconsole] [--version] [inpath]
 
 RIDE can be started either without any arguments or by giving a path to a test
 data file or directory to be opened.
@@ -22,6 +22,8 @@ data file or directory to be opened.
 To disable update checker use --noupdatecheck.
 
 To start debug console for RIDE problem debugging use --debugconsole option.
+
+To see RIDE's version use --version.
 
 RIDE's API is still evolving while the project is moving towards the 1.0
 release. The most stable, and best documented, module is `robotide.pluginapi`.
@@ -33,30 +35,22 @@ from string import Template
 
 errorMessageTemplate = Template("""$reason
 You need to install wxPython 2.8.12.1 with unicode support to run RIDE.
-wxPython 2.8.12.1 can be downloaded from http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/""")
-supported_versions = ["2.8"]
+wxPython 2.8.12.1 can be downloaded from \
+http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/""")
 
 try:
-    import wxversion
-    from wxversion import VersionError
-    if sys.platform == 'darwin':
-        supported_versions.append("2.9")
-    wxversion.select(supported_versions)
     import wx
 except ImportError as e:
     if "no appropriate 64-bit architecture" in e.message.lower() and \
        sys.platform == 'darwin':
-        print "python should be executed in 32-bit mode with wxPython on OSX."
+        print("python should be executed in 32-bit mode with wxPython on OSX.")
     else:
-        print errorMessageTemplate.substitute(reason="wxPython not found.")
-    sys.exit(1)
-except VersionError:
-    print errorMessageTemplate.substitute(reason="Wrong wxPython version.")
+        print(errorMessageTemplate.substitute(reason="wxPython not found."))
     sys.exit(1)
 
 if "ansi" in wx.PlatformInfo:
-    print errorMessageTemplate.substitute(
-        reason="wxPython with ansi encoding is not supported")
+    print(errorMessageTemplate.substitute(
+        reason="wxPython with ansi encoding is not supported"))
     sys.exit(1)
 
 
@@ -67,8 +61,16 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'spec'))
 def main(*args):
     noupdatecheck, debug_console, inpath = _parse_args(args)
     if len(args) > 3 or '--help' in args:
-        print __doc__
+        print(__doc__)
         sys.exit()
+    if '--version' in args:
+        try:
+            import version
+        except ImportError:
+            print("Error getting RIDE version!")
+            sys.exit(1)
+        print(version.VERSION)
+        sys.exit(0)
     try:
         _run(inpath, not noupdatecheck, debug_console)
     except Exception:
@@ -82,7 +84,7 @@ def _parse_args(args):
         return False, False, None
     noupdatecheck = '--noupdatecheck' in args
     debug_console = '--debugconsole' in args
-    inpath = args[-1] if args[-1] not in ['--noupdatecheck', '--debugconsole'] \
+    inpath = args[-1] if args[-1] not in ['--noupdatecheck', '--debugconsole']\
         else None
     return noupdatecheck, debug_console, inpath
 
@@ -104,20 +106,38 @@ def _run(inpath=None, updatecheck=True, debug_console=False):
 
 
 def _show_old_wxpython_warning_if_needed(parent=None):
-    if wx.VERSION >= (2, 8, 12, 1):
+    if wx.VERSION >= (2, 8, 12, 1, ''):
+        if wx.VERSION > (2, 8, 12, 1, ''):
+            title = 'Please be aware of untested wxPython installation'
+            message = ('RIDE officially supports wxPython 2.8.12.1. '
+                       'Your current version is %s.\n\n'
+                       'There are significant changes in newer wxPython versio\
+ns. Notice that RIDE is still under development for wxPython 3.0.2 and newer (\
+wxPython-Phoenix).\n\n'
+                       'wxPython 2.8.12.1 packages can be found from\n'
+                       'http://sourceforge.net/projects/wxpython/files/wxPytho\
+n/2.8.12.1/.'
+                       % wx.VERSION_STRING)
+            style = wx.OK | wx.ICON_INFORMATION | wx.CENTER
+            if not parent:
+                _ = wx.App()
+                parent = wx.Frame(None, size=(0, 0))
+            wx.MessageDialog(parent, message, title, style).ShowModal()
         return
     title = 'Please upgrade your wxPython installation'
     message = ('RIDE officially supports wxPython 2.8.12.1. '
                'Your current version is %s.\n\n'
-               'Older wxPython versions are known to miss some features used by RIDE. '
+               'Older wxPython versions are known to miss some features used b\
+y RIDE. '
                'Notice also that wxPython 3.0 is not yet supported.\n\n'
                'wxPython 2.8.12.1 packages can be found from\n'
-               'http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/.'
+               'http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12\
+.1/.'
                % wx.VERSION_STRING)
     style = wx.ICON_EXCLAMATION
     if not parent:
-        _ = wx.PySimpleApp()
-        parent = wx.Frame(None, size=(0,0))
+        _ = wx.App()
+        parent = wx.Frame(None, size=(0, 0))
     wx.MessageDialog(parent, message, title, style).ShowModal()
 
 


### PR DESCRIPTION
Documentation will be updated later.

List of significant changes:
Creates desktop shortcuts for all platforms.
Adds a --version option to RIDE.
Removed wxversion checks from \_\_init\_\_.py. Added warning about proper wx version to use.
Completed ride_postinstall for Linux.
Changed setup.py to use setuptools and ez_setup.
Corrected windows detection, and arguments for post_install.
Create a Desktop shortcut to Linux script starting RIDE.
This is a minimal solution to have shortcut in Mac OS X.
Calls ride_postinstall.py after install.
Added ride_postinstall to run after setup.py or pip.
Removed verify_install when in Windows. Now ride_postinstall can be run standalone in all operative systems.
Asks to create Desktop shortcut in Windows.
Executable installer in Windows shows error but completes.
Introduces a new dependency pywin32 (packages only from sourceforge).
Fixed user detection on installs with "sudo".

ride_postinstall.py is not compatible with Python 2.6.