### PR TITLE
Removes wxversion

### DIFF
--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -109,15 +109,15 @@ def _show_old_wxpython_warning_if_needed(parent=None):
     if wx.VERSION >= (2, 8, 12, 1, ''):
         if wx.VERSION > (2, 8, 12, 1, ''):
             title = "Please be aware of untested wxPython installation"
-            message = ("RIDE officially supports wxPython 2.8.12.1."
-                       "Your current version is %s."
+            message = ("RIDE officially supports wxPython 2.8.12.1. Your "
+                       "current version is %s."
                        "\n"
                        "There are significant changes in newer wxPython "
                        "versions. Notice that RIDE is still under development "
                        "for wxPython 3.0.2 and newer (wxPython-Phoenix). "
-                       "wxPython 2.8.12.1 packages can be found from "
-                       "http://sourceforge.net/projects/wxpython/files/"
-                       "wxPython/2.8.12.1/."
+                       "wxPython 2.8.12.1 packages can be found from http://"
+                       "sourceforge.net/projects/wxpython/files/wxPython/"
+                       "2.8.12.1/."
                        % wx.VERSION_STRING)
             style = wx.OK | wx.ICON_INFORMATION | wx.CENTER
             if not parent:
@@ -128,16 +128,13 @@ def _show_old_wxpython_warning_if_needed(parent=None):
                              style=style).ShowModal()
     else:
         title = "Please upgrade your wxPython installation"
-        message = ("RIDE officially supports wxPython 2.8.12.1. "
-                   "Your current version is %s. "
+        message = ("RIDE officially supports wxPython 2.8.12.1. Your current "
+                   "version is %s."
                    "\n"
                    "Older wxPython versions are known to miss some features "
-                   "used "
-                   "by RIDE. "
-                   "Notice also that wxPython 3.0 is considered experimental."
-                   "\n"
-                   "wxPython 2.8.12.1 packages can be found from "
-                   "http://sourceforge.net/projects/wxpython/files/wxPython/"
+                   "used by RIDE. Notice also that wxPython 3.0 is considered "
+                   "experimental. wxPython 2.8.12.1 packages can be found from"
+                   " http://sourceforge.net/projects/wxpython/files/wxPython/"
                    "2.8.12.1/."
                    % wx.VERSION_STRING)
         style = wx.ICON_EXCLAMATION

--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -14,7 +14,7 @@
 
 """RIDE -- Robot Framework test data editor
 
-Usage: ride.py [--noupdatecheck] [--debugconsole] [inpath]
+Usage: ride.py [--noupdatecheck] [--debugconsole] [--version] [inpath]
 
 RIDE can be started either without any arguments or by giving a path to a test
 data file or directory to be opened.
@@ -22,6 +22,8 @@ data file or directory to be opened.
 To disable update checker use --noupdatecheck.
 
 To start debug console for RIDE problem debugging use --debugconsole option.
+
+To see RIDE's version use --version.
 
 RIDE's API is still evolving while the project is moving towards the 1.0
 release. The most stable, and best documented, module is `robotide.pluginapi`.
@@ -33,7 +35,8 @@ from string import Template
 
 errorMessageTemplate = Template("""$reason
 You need to install wxPython 2.8.12.1 with unicode support to run RIDE.
-wxPython 2.8.12.1 can be downloaded from http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/""")
+wxPython 2.8.12.1 can be downloaded from http://sourceforge.net/projects/wxpyt\
+hon/files/wxPython/2.8.12.1/""")
 supported_versions = ["2.8"]
 
 try:
@@ -46,17 +49,17 @@ try:
 except ImportError as e:
     if "no appropriate 64-bit architecture" in e.message.lower() and \
        sys.platform == 'darwin':
-        print "python should be executed in 32-bit mode with wxPython on OSX."
+        print("python should be executed in 32-bit mode with wxPython on OSX.")
     else:
-        print errorMessageTemplate.substitute(reason="wxPython not found.")
+        print(errorMessageTemplate.substitute(reason="wxPython not found."))
     sys.exit(1)
 except VersionError:
-    print errorMessageTemplate.substitute(reason="Wrong wxPython version.")
+    print(errorMessageTemplate.substitute(reason="Wrong wxPython version."))
     sys.exit(1)
 
 if "ansi" in wx.PlatformInfo:
-    print errorMessageTemplate.substitute(
-        reason="wxPython with ansi encoding is not supported")
+    print(errorMessageTemplate.substitute(
+        reason="wxPython with ansi encoding is not supported"))
     sys.exit(1)
 
 
@@ -67,8 +70,16 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'spec'))
 def main(*args):
     noupdatecheck, debug_console, inpath = _parse_args(args)
     if len(args) > 3 or '--help' in args:
-        print __doc__
+        print(__doc__)
         sys.exit()
+    if '--version' in args:
+        try:
+            import version
+        except ImportError:
+            print("Error getting RIDE version!")
+            sys.exit(1)
+        print(version.VERSION)
+        sys.exit(0)
     try:
         _run(inpath, not noupdatecheck, debug_console)
     except Exception:
@@ -82,7 +93,7 @@ def _parse_args(args):
         return False, False, None
     noupdatecheck = '--noupdatecheck' in args
     debug_console = '--debugconsole' in args
-    inpath = args[-1] if args[-1] not in ['--noupdatecheck', '--debugconsole'] \
+    inpath = args[-1] if args[-1] not in ['--noupdatecheck', '--debugconsole']\
         else None
     return noupdatecheck, debug_console, inpath
 
@@ -109,15 +120,17 @@ def _show_old_wxpython_warning_if_needed(parent=None):
     title = 'Please upgrade your wxPython installation'
     message = ('RIDE officially supports wxPython 2.8.12.1. '
                'Your current version is %s.\n\n'
-               'Older wxPython versions are known to miss some features used by RIDE. '
+               'Older wxPython versions are known to miss some features used b\
+y RIDE. '
                'Notice also that wxPython 3.0 is not yet supported.\n\n'
                'wxPython 2.8.12.1 packages can be found from\n'
-               'http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/.'
+               'http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12\
+.1/.'
                % wx.VERSION_STRING)
     style = wx.ICON_EXCLAMATION
     if not parent:
-        _ = wx.PySimpleApp()
-        parent = wx.Frame(None, size=(0,0))
+        _ = wx.App()
+        parent = wx.Frame(None, size=(0, 0))
     wx.MessageDialog(parent, message, title, style).ShowModal()
 
 

--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -84,8 +84,8 @@ def _parse_args(args):
         return False, False, None
     noupdatecheck = '--noupdatecheck' in args
     debug_console = '--debugconsole' in args
-    inpath = args[-1] if args[-1] not in ['--noupdatecheck', '--debugconsole']\
-        else None
+    inpath = args[-1] if args[-1] not in ['--noupdatecheck',
+                                          '--debugconsole'] else None
     return noupdatecheck, debug_console, inpath
 
 
@@ -99,7 +99,7 @@ def _run(inpath=None, updatecheck=True, debug_console=False):
     if inpath:
         inpath = unicode(inpath, sys.getfilesystemencoding())
     ride = RIDE(inpath, updatecheck)
-    _show_old_wxpython_warning_if_needed(ride.frame)
+    wx.CallAfter(_show_old_wxpython_warning_if_needed, ride.frame)
     if debug_console:
         debugconsole.start(ride)
     ride.MainLoop()
@@ -114,7 +114,7 @@ def _show_old_wxpython_warning_if_needed(parent=None):
                        "\n"
                        "There are significant changes in newer wxPython "
                        "versions. Notice that RIDE is still under development "
-                       "for wxPython 3.0.2 and newer (wxPython-Phoenix)."
+                       "for wxPython 3.0.2 and newer (wxPython-Phoenix). "
                        "wxPython 2.8.12.1 packages can be found from "
                        "http://sourceforge.net/projects/wxpython/files/"
                        "wxPython/2.8.12.1/."
@@ -124,26 +124,29 @@ def _show_old_wxpython_warning_if_needed(parent=None):
                 _ = wx.App()
                 parent = wx.Frame(None, size=(0, 0))
             sys.stderr.write("{0}\n{1}\n".format(title, message))
-            wx.MessageDialog(parent, message, title, style).ShowModal()
-        return
-    title = "Please upgrade your wxPython installation"
-    message = ("RIDE officially supports wxPython 2.8.12.1. "
-               "Your current version is %s. "
-               "\n"
-               "Older wxPython versions are known to miss some features used "
-               "by RIDE. "
-               "Notice also that wxPython 3.0 is not yet supported. "
-               "\n"
-               "wxPython 2.8.12.1 packages can be found from "
-               "http://sourceforge.net/projects/wxpython/files/wxPython/"
-               "2.8.12.1/."
-               % wx.VERSION_STRING)
-    style = wx.ICON_EXCLAMATION
-    if not parent:
-        _ = wx.App()
-        parent = wx.Frame(None, size=(0, 0))
-    sys.stderr.write("{0}\n{1}\n".format(title, message))
-    wx.MessageDialog(parent, message, title, style).ShowModal()
+            wx.MessageDialog(parent, message=message, caption=title,
+                             style=style).ShowModal()
+    else:
+        title = "Please upgrade your wxPython installation"
+        message = ("RIDE officially supports wxPython 2.8.12.1. "
+                   "Your current version is %s. "
+                   "\n"
+                   "Older wxPython versions are known to miss some features "
+                   "used "
+                   "by RIDE. "
+                   "Notice also that wxPython 3.0 is considered experimental."
+                   "\n"
+                   "wxPython 2.8.12.1 packages can be found from "
+                   "http://sourceforge.net/projects/wxpython/files/wxPython/"
+                   "2.8.12.1/."
+                   % wx.VERSION_STRING)
+        style = wx.ICON_EXCLAMATION
+        if not parent:
+            _ = wx.App()
+            parent = wx.Frame(None, size=(0, 0))
+        sys.stderr.write("{0}\n{1}\n".format(title, message))
+        wx.MessageDialog(parent, message=message, caption=title,
+                         style=style).ShowModal()
 
 
 if __name__ == '__main__':

--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -35,7 +35,7 @@ from string import Template
 
 errorMessageTemplate = Template("""$reason
 You need to install wxPython 2.8.12.1 with unicode support to run RIDE.
-wxPython 2.8.12.1 can be downloaded from \
+wxPython 2.8.12.1 can be downloaded from
 http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/""")
 
 try:
@@ -65,7 +65,7 @@ def main(*args):
         sys.exit()
     if '--version' in args:
         try:
-            import version
+            from robotide import version
         except ImportError:
             print("Error getting RIDE version!")
             sys.exit(1)
@@ -108,36 +108,41 @@ def _run(inpath=None, updatecheck=True, debug_console=False):
 def _show_old_wxpython_warning_if_needed(parent=None):
     if wx.VERSION >= (2, 8, 12, 1, ''):
         if wx.VERSION > (2, 8, 12, 1, ''):
-            title = 'Please be aware of untested wxPython installation'
-            message = ('RIDE officially supports wxPython 2.8.12.1. '
-                       'Your current version is %s.\n\n'
-                       'There are significant changes in newer wxPython versio\
-ns. Notice that RIDE is still under development for wxPython 3.0.2 and newer (\
-wxPython-Phoenix).\n\n'
-                       'wxPython 2.8.12.1 packages can be found from\n'
-                       'http://sourceforge.net/projects/wxpython/files/wxPytho\
-n/2.8.12.1/.'
+            title = "Please be aware of untested wxPython installation"
+            message = ("RIDE officially supports wxPython 2.8.12.1."
+                       "Your current version is %s."
+                       "\n"
+                       "There are significant changes in newer wxPython "
+                       "versions. Notice that RIDE is still under development "
+                       "for wxPython 3.0.2 and newer (wxPython-Phoenix)."
+                       "wxPython 2.8.12.1 packages can be found from "
+                       "http://sourceforge.net/projects/wxpython/files/"
+                       "wxPython/2.8.12.1/."
                        % wx.VERSION_STRING)
             style = wx.OK | wx.ICON_INFORMATION | wx.CENTER
             if not parent:
                 _ = wx.App()
                 parent = wx.Frame(None, size=(0, 0))
+            sys.stderr.write("{0}\n{1}\n".format(title, message))
             wx.MessageDialog(parent, message, title, style).ShowModal()
         return
-    title = 'Please upgrade your wxPython installation'
-    message = ('RIDE officially supports wxPython 2.8.12.1. '
-               'Your current version is %s.\n\n'
-               'Older wxPython versions are known to miss some features used b\
-y RIDE. '
-               'Notice also that wxPython 3.0 is not yet supported.\n\n'
-               'wxPython 2.8.12.1 packages can be found from\n'
-               'http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12\
-.1/.'
+    title = "Please upgrade your wxPython installation"
+    message = ("RIDE officially supports wxPython 2.8.12.1. "
+               "Your current version is %s. "
+               "\n"
+               "Older wxPython versions are known to miss some features used "
+               "by RIDE. "
+               "Notice also that wxPython 3.0 is not yet supported. "
+               "\n"
+               "wxPython 2.8.12.1 packages can be found from "
+               "http://sourceforge.net/projects/wxpython/files/wxPython/"
+               "2.8.12.1/."
                % wx.VERSION_STRING)
     style = wx.ICON_EXCLAMATION
     if not parent:
         _ = wx.App()
         parent = wx.Frame(None, size=(0, 0))
+    sys.stderr.write("{0}\n{1}\n".format(title, message))
     wx.MessageDialog(parent, message, title, style).ShowModal()
 
 

--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -35,16 +35,10 @@ from string import Template
 
 errorMessageTemplate = Template("""$reason
 You need to install wxPython 2.8.12.1 with unicode support to run RIDE.
-wxPython 2.8.12.1 can be downloaded from http://sourceforge.net/projects/wxpyt\
-hon/files/wxPython/2.8.12.1/""")
-supported_versions = ["2.8"]
+wxPython 2.8.12.1 can be downloaded from \
+http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/""")
 
 try:
-    import wxversion
-    from wxversion import VersionError
-    if sys.platform == 'darwin':
-        supported_versions.append("2.9")
-    wxversion.select(supported_versions)
     import wx
 except ImportError as e:
     if "no appropriate 64-bit architecture" in e.message.lower() and \
@@ -52,9 +46,6 @@ except ImportError as e:
         print("python should be executed in 32-bit mode with wxPython on OSX.")
     else:
         print(errorMessageTemplate.substitute(reason="wxPython not found."))
-    sys.exit(1)
-except VersionError:
-    print(errorMessageTemplate.substitute(reason="Wrong wxPython version."))
     sys.exit(1)
 
 if "ansi" in wx.PlatformInfo:
@@ -115,7 +106,23 @@ def _run(inpath=None, updatecheck=True, debug_console=False):
 
 
 def _show_old_wxpython_warning_if_needed(parent=None):
-    if wx.VERSION >= (2, 8, 12, 1):
+    if wx.VERSION >= (2, 8, 12, 1, ''):
+        if wx.VERSION > (2, 8, 12, 1, ''):
+            title = 'Please be aware of untested wxPython installation'
+            message = ('RIDE officially supports wxPython 2.8.12.1. '
+                       'Your current version is %s.\n\n'
+                       'There are significant changes in newer wxPython versio\
+ns. Notice that RIDE is still under development for wxPython 3.0.2 and newer (\
+wxPython-Phoenix).\n\n'
+                       'wxPython 2.8.12.1 packages can be found from\n'
+                       'http://sourceforge.net/projects/wxpython/files/wxPytho\
+n/2.8.12.1/.'
+                       % wx.VERSION_STRING)
+            style = wx.OK | wx.ICON_INFORMATION | wx.CENTER
+            if not parent:
+                _ = wx.App()
+                parent = wx.Frame(None, size=(0, 0))
+            wx.MessageDialog(parent, message, title, style).ShowModal()
         return
     title = 'Please upgrade your wxPython installation'
     message = ('RIDE officially supports wxPython 2.8.12.1. '

--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -126,6 +126,8 @@ def _show_old_wxpython_warning_if_needed(parent=None):
             sys.stderr.write("{0}\n{1}\n".format(title, message))
             wx.MessageDialog(parent, message=message, caption=title,
                              style=style).ShowModal()
+            parent.Destroy()
+            sys.exit(1)
     else:
         title = "Please upgrade your wxPython installation"
         message = ("RIDE officially supports wxPython 2.8.12.1. Your current "

--- a/src/robotide/publish/__init__.py
+++ b/src/robotide/publish/__init__.py
@@ -119,8 +119,8 @@ the `robotide.pluginapi` module and plugins should import them there.
 
 import os
 
-from messages import *
-from publisher import PUBLISHER
+from .messages import *
+from .publisher import PUBLISHER
 
 
 def get_html_message(name):

--- a/src/robotide/publish/messages.py
+++ b/src/robotide/publish/messages.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+
 import inspect
 import sys
 import traceback


### PR DESCRIPTION
This simplifies wx use, because user may choose what wx version to use. Proper warnings are shown if version is not supported.
Fixes #1569. 