### PR TITLE
Fixes #1556, by ignoring starting Gherkin keywords.

### DIFF
--- a/src/robotide/controller/commands.py
+++ b/src/robotide/controller/commands.py
@@ -290,8 +290,8 @@ class RenameKeywordOccurrences(_ReversibleCommand):
         self._occurrences = None
 
     def _check_gherkin(self, new_name, original_name):
-        was_gherkin, keyword_name = self._get_gerkin(original_name)
-        is_gherkin, new_keyword_name = self._get_gerkin(new_name)
+        was_gherkin, keyword_name = self._get_gherkin(original_name)
+        is_gherkin, new_keyword_name = self._get_gherkin(new_name)
         if was_gherkin and not is_gherkin:
             keyword_name = original_name
         if not was_gherkin and is_gherkin:
@@ -306,7 +306,7 @@ class RenameKeywordOccurrences(_ReversibleCommand):
                 keyword_name = original_name
         return keyword_name, new_keyword_name
 
-    def _get_gerkin(self, original_name):
+    def _get_gherkin(self, original_name):
         keyword_value = re.sub(self._gherkin_prefix, '', original_name)
         value_is_gherkin = (keyword_value != original_name)
         return value_is_gherkin, keyword_value

--- a/src/robotide/controller/commands.py
+++ b/src/robotide/controller/commands.py
@@ -15,6 +15,7 @@
 from itertools import chain
 import time
 import os
+import re
 
 from robotide.namespace.embeddedargs import EmbeddedArgsHandler
 from robotide.publish.messages import RideSelectResource, RideFileNameChanged,\
@@ -278,12 +279,37 @@ class NullObserver(object):
 
 class RenameKeywordOccurrences(_ReversibleCommand):
 
+    _gherkin_prefix = re.compile('^(Given|When|Then|And|But) ', re.IGNORECASE)
+
     def __init__(self, original_name, new_name, observer, keyword_info=None):
-        self._original_name = original_name
-        self._new_name = new_name
+        self._original_name, self._new_name = self._check_gherkin(new_name,
+                                                                  original_name
+                                                                  )
         self._observer = observer
         self._keyword_info = keyword_info
         self._occurrences = None
+
+    def _check_gherkin(self, new_name, original_name):
+        was_gherkin, keyword_name = self._get_gerkin(original_name)
+        is_gherkin, new_keyword_name = self._get_gerkin(new_name)
+        if was_gherkin and not is_gherkin:
+            keyword_name = original_name
+        if not was_gherkin and is_gherkin:
+            # When we change non-gherkin to gherkin, the keyword changes too.
+            # The workaround is not to Rename keyword, but only edit field.
+            new_keyword_name = new_name
+        if was_gherkin and is_gherkin:
+            # Check if the first word has changed
+            if original_name.split(' ', 1)[0].lower() != new_name.split(
+                    ' ', 1)[0].lower():
+                new_keyword_name = new_name
+                keyword_name = original_name
+        return keyword_name, new_keyword_name
+
+    def _get_gerkin(self, original_name):
+        keyword_value = re.sub(self._gherkin_prefix, '', original_name)
+        value_is_gherkin = (keyword_value != original_name)
+        return value_is_gherkin, keyword_value
 
     def _params(self):
         return (self._original_name, self._new_name,

--- a/utest/controller/test_rename_keywords.py
+++ b/utest/controller/test_rename_keywords.py
@@ -1,0 +1,60 @@
+import unittest
+from robotide.controller.commands import *
+from nose.tools import assert_true, assert_false, assert_equals
+
+from base_command_test import TestCaseCommandTest
+
+
+class TestRenameKeywords(TestCaseCommandTest):
+
+    def test_test_is_gerkin_kw(self):
+        observer = NullObserver()
+        myobject = RenameKeywordOccurrences("Step 1", "My New Keyword", observer)
+        # ._get_gherkin("keyword value")
+        is_gherkin, kw_value = myobject._get_gherkin("Given a Keyword")
+        assert_true(is_gherkin)
+        assert_equals(kw_value, "a Keyword")
+        is_gherkin, kw_value = myobject._get_gherkin("Then a Keyword")
+        assert_true(is_gherkin)
+        assert_equals(kw_value, "a Keyword")
+        is_gherkin, kw_value = myobject._get_gherkin("And a Keyword")
+        assert_true(is_gherkin)
+        assert_equals(kw_value, "a Keyword")
+        is_gherkin, kw_value = myobject._get_gherkin("When a Keyword")
+        assert_true(is_gherkin)
+        assert_equals(kw_value, "a Keyword")
+        is_gherkin, kw_value = myobject._get_gherkin("But a Keyword")
+        assert_true(is_gherkin)
+        assert_equals(kw_value, "a Keyword")
+        is_gherkin, kw_value = myobject._get_gherkin("But Given a Keyword")
+        assert_true(is_gherkin)
+        assert_equals(kw_value, "Given a Keyword")
+        is_gherkin, kw_value = myobject._get_gherkin("If a Keyword")
+        assert_false(is_gherkin)
+        assert_equals(kw_value, "If a Keyword")
+
+    def test_check_gerkin_kw(self):
+        observer = NullObserver()
+        myobject = RenameKeywordOccurrences("Step 1", "My New Keyword", observer)
+        # ._check_gherkin("new keyword value", "original keyword value")
+        original_kw, new_kw = myobject._check_gherkin("Given a Keyword", "a Keyword")
+        assert_equals(new_kw, "Given a Keyword")
+        assert_equals(original_kw, "a Keyword")
+        original_kw, new_kw = myobject._check_gherkin("a Keyword", "Given a Keyword")
+        assert_equals(new_kw, "a Keyword")
+        assert_equals(original_kw, "Given a Keyword")
+        original_kw, new_kw = myobject._check_gherkin("When a Keyword", "Given a Keyword")
+        assert_equals(new_kw, "When a Keyword")
+        assert_equals(original_kw, "Given a Keyword")
+        original_kw, new_kw = myobject._check_gherkin("My new Keyword", "Old Keyword")
+        assert_equals(new_kw, "My new Keyword")
+        assert_equals(original_kw, "Old Keyword")
+        original_kw, new_kw = myobject._check_gherkin("But Given a new Keyword", "Given a new Keyword")
+        assert_equals(new_kw, "But Given a new Keyword")
+        assert_equals(original_kw, "Given a new Keyword")
+        original_kw, new_kw = myobject._check_gherkin("Given a new Keyword", "Given an old Keyword")
+        assert_equals(new_kw, "a new Keyword")
+        assert_equals(original_kw, "an old Keyword")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There is a known bug. This is the comment in code:
-# When we change non-gherkin to gherkin, the keyword changes too.
-# The workaround is not to Rename keyword, but only edit field.