### PR TITLE
1629 - RIDE will not run in ubuntu 16.04

### DIFF
--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -304,7 +304,7 @@ class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl,
 
         if isinstance(controller, ResourceFileController):
             if not controller.is_used():
-                self.SetItemTextColour(node, wx.ColorRGB(0xA9A9A9))
+                self.SetItemTextColour(node, wx.Colour(169, 169, 169))
         action_handler = handler_class(
             controller, self, node, self._controller.settings)
         self.SetPyData(node, action_handler)

--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -304,7 +304,7 @@ class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl,
 
         if isinstance(controller, ResourceFileController):
             if not controller.is_used():
-                self.SetItemTextColour(node, wx.Colour(169, 169, 169))
+                self.SetItemTextColour(node, wx.Colour(0xA9, 0xA9, 0xA9))
         action_handler = handler_class(
             controller, self, node, self._controller.settings)
         self.SetPyData(node, action_handler)


### PR DESCRIPTION
- Ubuntu 16.04 runs the 3.x wx libraries from the xenial repositories,
  and it seems the wx.RGBcolour object has been deprecated. So I have
  converted it to use the base wx.Colour object, converting the hex
  to 3 part RGB
- 'invoke test' now passes all tests with this change in place
