### PR TITLE
Fix #1747

### DIFF
--- a/src/robotide/contrib/testrunner/testrunner.py
+++ b/src/robotide/contrib/testrunner/testrunner.py
@@ -474,7 +474,7 @@ class StreamReaderThread(object):
                 # .decode(utils.SYSTEM_ENCODING, 'replace')
                 # .decode('UTF-8','ignore')
                 result += encoding.console_decode(self._queue.get_nowait(),
-                                                  'latin1' if IS_WINDOWS
+                                                  'mbcs' if IS_WINDOWS
                                                   else 'UTF-8')
                 # ,'replace')  # 'latin1' .decode(utils.SYSTEM_ENCODING,
                 # 'replace')  # .decode('UTF-8','ignore')


### PR DESCRIPTION
Fixed 1747，Use the encoding "mbcs" to decode the output of robot.exe according to the ANSI codepage (CP_ACP).