### PR TITLE
Add a file explorer

### DIFF
--- a/src/robotide/controller/project.py
+++ b/src/robotide/controller/project.py
@@ -152,6 +152,8 @@ class Project(_BaseController, WithNamespace):
         if datafile:
             return datafile
         load_observer.error("Invalid data file '%s'." % path)
+        e = UserWarning("Invalid data file")
+        return e
 
     def _load_datafile(self, path, load_observer):
         datafile = self._loader.load_datafile(path, load_observer)

--- a/src/robotide/editor/customsourceeditor.py
+++ b/src/robotide/editor/customsourceeditor.py
@@ -75,7 +75,7 @@ wildcard = "All files (*.*)|*.*|"                \
            "Python source (*.py)|*.py|"         \
            "Robot Framework (*.robot)|*.robot|" \
            "Robot Framework (*.txt)|*.txt|" \
-           "YAML file (*.yml)|*.yml"
+           "YAML file (*.yaml)|*.yaml"
 
 
 
@@ -600,9 +600,10 @@ def isUTF8Strict(data):
                 return False
         return True
 
+
 class DemoCodePanel(wx.Panel):
     """Panel for the 'Demo Code' tab"""
-    def __init__(self, parent, mainFrame):
+    def __init__(self, parent, mainFrame, path=None):
         self.log = sys.stdout  # From FileDialog
         wx.Panel.__init__(self, parent, size=(1,1))
         #if 'wxMSW' in wx.PlatformInfo:
@@ -648,6 +649,8 @@ class DemoCodePanel(wx.Panel):
 
         self.box.Fit(self)
         self.SetSizer(self.box)
+        if path:
+            self.LoadFile(path)
 
     # # Loads a demo from a DemoModules object
     # def LoadDemo(self, demoModules):
@@ -658,6 +661,15 @@ class DemoCodePanel(wx.Panel):
     #         demoModules.SetActive(modOriginal)
     #     self.radioButtons[demoModules.GetActiveID()].Enable(True)
     #     self.ActiveModuleChanged()
+
+    def LoadFile(self, path):
+        # Open
+        f = open(path, "rb")
+        try:
+            source = f.read()
+        finally:
+            f.close()
+        self.LoadDemoSource(source)
 
     def ActiveModuleChanged(self):
         self.LoadDemoSource(self.demoModules.GetSource())
@@ -778,7 +790,7 @@ class DemoCodePanel(wx.Panel):
 
     def OnButton(self, evt):
         #self.log.WriteText("CWD: %s\n" % os.getcwd())
-        self.log.write("CWD: %s\n" % os.getcwd())
+        # self.log.write("CWD: %s\n" % os.getcwd())
 
         # Create the dialog. In this case the current directory is forced as the starting
         # directory for the dialog, and no default file name is forced. This can easilly
@@ -817,11 +829,11 @@ class DemoCodePanel(wx.Panel):
             finally:
                 f.close()
 
-            self.log.write('%s\n' % source)
+            # self.log.write('%s\n' % source)
             self.LoadDemoSource(source)  # Just the last file
         # Compare this with the debug above; did we change working dirs?
         # self.log.WriteText("CWD: %s\n" % os.getcwd())
-        self.log.write("CWD: %s\n" % os.getcwd())
+        # self.log.write("CWD: %s\n" % os.getcwd())
 
         # Destroy the dialog. Don't do this until you are done with it!
         # BAD things can happen otherwise!
@@ -829,7 +841,7 @@ class DemoCodePanel(wx.Panel):
 
     def OnButton2(self, evt):
         #self.log.WriteText("CWD: %s\n" % os.getcwd())
-        self.log.write("CWD: %s\n" % os.getcwd())
+        # self.log.write("CWD: %s\n" % os.getcwd())
 
         # Create the dialog. In this case the current directory is forced as the starting
         # directory for the dialog, and no default file name is forced. This can easilly
@@ -852,7 +864,7 @@ class DemoCodePanel(wx.Panel):
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             # self.log.WriteText('You selected "%s"' % path)
-            self.log.write('You selected "%s"\n' % path)
+            # self.log.write('You selected "%s"\n' % path)
 
             # Normally, at this point you would save your data using the file and path
             # data that the user provided to you, but since we didn't actually start
@@ -871,7 +883,7 @@ class DemoCodePanel(wx.Panel):
         # Note that the current working dir didn't change. This is good since
         # that's the way we set it up.
         # self.log.WriteText("CWD: %s\n" % os.getcwd())
-        self.log.write("CWD: %s\n" % os.getcwd())
+        # self.log.write("CWD: %s\n" % os.getcwd())
 
         # Destroy the dialog. Don't do this until you are done with it!
         # BAD things can happen otherwise!
@@ -959,6 +971,14 @@ def GetConfig():
 
 _platformNames = ["wxMSW", "wxGTK", "wxMac"]
 
+
+def main(filepath):
+    __name__ = 'Editor'
+    app = wx.App()
+    frame = wx.Frame(None)
+    panel = DemoCodePanel(frame, None, filepath)
+    frame.Show(True)
+    app.MainLoop()
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------
@@ -967,11 +987,8 @@ _platformNames = ["wxMSW", "wxGTK", "wxMac"]
 if __name__ == '__main__' and __package__ is None:
     from os import sys, path
     sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
-    __name__ = 'Editor'
-    app = wx.App()
-    frame = wx.Frame(None)
-    panel = DemoCodePanel(frame, None)
-    frame.Show(True)
-    app.MainLoop()
-
+    path = None
+    if sys.argv[1]:
+        path = sys.argv[1]
+    main(path)
 # ----------------------------------------------------------------------------

--- a/src/robotide/editor/customsourceeditor.py
+++ b/src/robotide/editor/customsourceeditor.py
@@ -31,9 +31,9 @@ import wx.stc as stc
 
 # ----------------------------------------------------------------------
 
-demoText = """\
+CodeText = """\
 ## This version of the editor has been set up to edit Python source
-## code.  Here is a copy of wxPython/demo/Main.py to play with.
+## code.  Here is a copy of wxPython/Code/Main.py to play with.
 
 
 """
@@ -42,32 +42,31 @@ demoText = """\
 
 
 if wx.Platform == '__WXMSW__':
-    faces = { 'times': 'Times New Roman',
-              'mono' : 'Courier New',
-              'helv' : 'Arial',
-              'other': 'Comic Sans MS',
-              'size' : 10,
-              'size2': 8,
+    faces = {'times': 'Times New Roman',
+             'mono': 'Courier New',
+             'helv': 'Arial',
+             'other': 'Comic Sans MS',
+             'size': 10,
+             'size2': 8,
              }
 elif wx.Platform == '__WXMAC__':
-    faces = { 'times': 'Times New Roman',
-              'mono' : 'Monaco',
-              'helv' : 'Arial',
-              'other': 'Comic Sans MS',
-              'size' : 12,
-              'size2': 10,
+    faces = {'times': 'Times New Roman',
+             'mono': 'Monaco',
+             'helv': 'Arial',
+             'other': 'Comic Sans MS',
+             'size': 12,
+             'size2': 10,
              }
 else:
-    faces = { 'times': 'Times',
-              'mono' : 'Courier',
-              'helv' : 'Helvetica',
-              'other': 'new century schoolbook',
-              'size' : 12,
-              'size2': 10,
+    faces = {'times': 'Times',
+             'mono': 'Courier',
+             'helv': 'Helvetica',
+             'other': 'new century schoolbook',
+             'size': 12,
+             'size2': 10,
              }
 
-#---------------------------------------------------------------------------
-
+# ---------------------------------------------------------------------------
 # This is how you pre-establish a file filter so that the dialog
 # only shows the extension(s) you want it to.
 wildcard = "All files (*.*)|*.*|"                \
@@ -76,10 +75,8 @@ wildcard = "All files (*.*)|*.*|"                \
            "Robot Framework (*.robot)|*.robot|" \
            "Robot Framework (*.txt)|*.txt|" \
            "YAML file (*.yaml)|*.yaml"
-
-
-
 # ----------------------------------------------------------------------
+
 
 class PythonSTC(stc.StyledTextCtrl):
 
@@ -386,7 +383,7 @@ class PythonSTC(stc.StyledTextCtrl):
 # ----------------------------------------------------------------------
 
 
-class DemoCodeEditor(PythonSTC):
+class SourceCodeEditor(PythonSTC):
     def __init__(self, parent, style=wx.BORDER_NONE):
         PythonSTC.__init__(self, parent, -1, style=style)
         self.SetUpEditor()
@@ -443,7 +440,7 @@ class DemoCodeEditor(PythonSTC):
 
     def SetUpEditor(self):
         """
-        This method carries out the work of setting up the demo editor.
+        This method carries out the work of setting up the Code editor.
         It's seperate so as not to clutter up the init code.
         """
         import keyword
@@ -452,7 +449,7 @@ class DemoCodeEditor(PythonSTC):
         self.SetKeyWords(0, " ".join(keyword.kwlist))
 
         # Enable folding
-        self.SetProperty("fold", "1" )
+        self.SetProperty("fold", "1")
 
         # Highlight tab/space mixing (shouldn't be any)
         self.SetProperty("tab.timmy.whinge.level", "1")
@@ -466,13 +463,14 @@ class DemoCodeEditor(PythonSTC):
         self.SetMarginWidth(1, 40)
 
         # Indentation and tab stuff
-        self.SetIndent(4)               # Proscribed indent size for wx
-        self.SetIndentationGuides(True) # Show indent guides
-        self.SetBackSpaceUnIndents(True)# Backspace unindents rather than delete 1 space
-        self.SetTabIndents(True)        # Tab key indents
-        self.SetTabWidth(4)             # Proscribed tab size for wx
-        self.SetUseTabs(False)          # Use spaces rather than tabs, or
-                                        # TabTimmy will complain!
+        self.SetIndent(4)                 # Proscribed indent size for wx
+        self.SetIndentationGuides(True)   # Show indent guides
+        self.SetBackSpaceUnIndents(True)  # Backspace unindents rather than
+                                          # delete 1 space
+        self.SetTabIndents(True)          # Tab key indents
+        self.SetTabWidth(4)               # Proscribed tab size for wx
+        self.SetUseTabs(False)            # Use spaces rather than tabs, or
+                                          # TabTimmy will complain!
         # White space
         self.SetViewWhiteSpace(False)   # Don't view white space
 
@@ -491,38 +489,19 @@ class DemoCodeEditor(PythonSTC):
         self.SetMarginSensitive(2, True)
         self.SetMarginWidth(2, 12)
 
-        """ DEBUG Let's use the ones in PythonSTC
-        # and now set up the fold markers
-        self.MarkerDefine(stc.STC_MARKNUM_FOLDEREND,     stc.STC_MARK_BOXPLUSCONNECTED,  "white", "black")
-        self.MarkerDefine(stc.STC_MARKNUM_FOLDEROPENMID, stc.STC_MARK_BOXMINUSCONNECTED, "white", "black")
-        self.MarkerDefine(stc.STC_MARKNUM_FOLDERMIDTAIL, stc.STC_MARK_TCORNER,  "white", "black")
-        self.MarkerDefine(stc.STC_MARKNUM_FOLDERTAIL,    stc.STC_MARK_LCORNER,  "white", "black")
-        self.MarkerDefine(stc.STC_MARKNUM_FOLDERSUB,     stc.STC_MARK_VLINE,    "white", "black")
-        self.MarkerDefine(stc.STC_MARKNUM_FOLDER,        stc.STC_MARK_BOXPLUS,  "white", "black")
-        self.MarkerDefine(stc.STC_MARKNUM_FOLDEROPEN,    stc.STC_MARK_BOXMINUS, "white", "black")
-        
-            # Like a flattened tree control using square headers
-            self.MarkerDefine(stc.STC_MARKNUM_FOLDEROPEN,    stc.STC_MARK_BOXMINUS,          "white", "#808080")
-            self.MarkerDefine(stc.STC_MARKNUM_FOLDER,        stc.STC_MARK_BOXPLUS,           "white", "#808080")
-            self.MarkerDefine(stc.STC_MARKNUM_FOLDERSUB,     stc.STC_MARK_VLINE,             "white", "#808080")
-            self.MarkerDefine(stc.STC_MARKNUM_FOLDERTAIL,    stc.STC_MARK_LCORNER,           "white", "#808080")
-            self.MarkerDefine(stc.STC_MARKNUM_FOLDEREND,     stc.STC_MARK_BOXPLUSCONNECTED,  "white", "#808080")
-            self.MarkerDefine(stc.STC_MARKNUM_FOLDEROPENMID, stc.STC_MARK_BOXMINUSCONNECTED, "white", "#808080")
-            self.MarkerDefine(stc.STC_MARKNUM_FOLDERMIDTAIL, stc.STC_MARK_TCORNER,           "white", "#808080")
-        """
         # Global default style
         if wx.Platform == '__WXMSW__':
             print("DEBUG: Setup on Windows")
             self.StyleSetSpec(stc.STC_STYLE_DEFAULT,
                               'fore:#000000,back:#FFFFFF,face:Space Mono')  # Courier New')
         elif wx.Platform == '__WXMAC__':
-            print("DEBUG: Setup on Mac")
+            # print("DEBUG: Setup on Mac")
             # TODO: if this looks fine on Linux too, remove the Mac-specific case
             # and use this whenever OS != MSW.
             self.StyleSetSpec(stc.STC_STYLE_DEFAULT,
                               'fore:#000000,back:#FFFFFF,face:Monaco')
         else:
-            print("DEBUG: Setup on Linux")
+            # print("DEBUG: Setup on Linux")
             defsize = wx.SystemSettings.GetFont(wx.SYS_ANSI_FIXED_FONT).GetPointSize()
             self.StyleSetSpec(stc.STC_STYLE_DEFAULT,
                               'fore:#000000,back:#FFFFFF,face:Hack,size:%d'%defsize)  # Courier, Space Mono, Source Pro Mono,
@@ -601,16 +580,13 @@ def isUTF8Strict(data):
         return True
 
 
-class DemoCodePanel(wx.Panel):
-    """Panel for the 'Demo Code' tab"""
+class CodeEditorPanel(wx.Panel):
+    """Panel for the 'Code Editor' tab"""
     def __init__(self, parent, mainFrame, path=None):
         self.log = sys.stdout  # From FileDialog
         wx.Panel.__init__(self, parent, size=(1,1))
-        #if 'wxMSW' in wx.PlatformInfo:
-        #    # print("DEBUG: Panel Hide on Windows")
-        #    # self.Hide()
         self.mainFrame = mainFrame
-        self.editor = DemoCodeEditor(self)
+        self.editor = SourceCodeEditor(self)
         self.editor.RegisterModifiedEvent(self.OnCodeModified)
 
         self.btnSave = wx.Button(self, -1, "Save Changes")
@@ -626,8 +602,9 @@ class DemoCodePanel(wx.Panel):
         self.btnSaveAs = wx.Button(self, -1, "Save as...")
         self.btnSaveAs.Bind(wx.EVT_BUTTON, self.OnButton2)
 
-        self.radioButtons = { modOriginal: wx.RadioButton(self, -1, "Original", style = wx.RB_GROUP),
-                              modModified: wx.RadioButton(self, -1, "Modified") }
+        self.radioButtons = {modOriginal: wx.RadioButton(self, -1, "Original",
+                                                         style = wx.RB_GROUP),
+                             modModified: wx.RadioButton(self, -1, "Modified")}
 
         self.controlBox = wx.BoxSizer(wx.HORIZONTAL)
         self.controlBox.Add(wx.StaticText(self, -1, "Active Version:"), 0,
@@ -652,16 +629,6 @@ class DemoCodePanel(wx.Panel):
         if path:
             self.LoadFile(path)
 
-    # # Loads a demo from a DemoModules object
-    # def LoadDemo(self, demoModules):
-    #     self.demoModules = demoModules
-    #     if (modDefault == modModified) and demoModules.Exists(modModified):
-    #         demoModules.SetActive(modModified)
-    #     else:
-    #         demoModules.SetActive(modOriginal)
-    #     self.radioButtons[demoModules.GetActiveID()].Enable(True)
-    #     self.ActiveModuleChanged()
-
     def LoadFile(self, path):
         # Open
         f = open(path, "rb")
@@ -669,16 +636,16 @@ class DemoCodePanel(wx.Panel):
             source = f.read()
         finally:
             f.close()
-        self.LoadDemoSource(source)
+        self.LoadSource(source)
 
     def ActiveModuleChanged(self):
-        self.LoadDemoSource(self.demoModules.GetSource())
+        self.LoadSource(self.CodeModules.GetSource())
         self.UpdateControlState()
         self.mainFrame.pnl.Freeze()
         self.ReloadDemo()
         self.mainFrame.pnl.Thaw()
 
-    def LoadDemoSource(self, source):
+    def LoadSource(self, source):
         self.editor.Clear()
         self.editor.SetTextRaw(source)  # DEBUG SetValue
         self.JumpToLine(0)
@@ -691,7 +658,7 @@ class DemoCodePanel(wx.Panel):
             self.editor.SelectLine(line)
 
     def UpdateControlState(self):
-        active = self.demoModules.GetActiveID()
+        active = self.CodeModules.GetActiveID()
         # Update the radio/restore buttons
         for moduleID in self.radioButtons:
             btn = self.radioButtons[moduleID]
@@ -700,7 +667,7 @@ class DemoCodePanel(wx.Panel):
             else:
                 btn.SetValue(False)
 
-            if self.demoModules.Exists(moduleID):
+            if self.CodeModules.Exists(moduleID):
                 btn.Enable(True)
                 if moduleID == modModified:
                     self.btnRestore.Enable(True)
@@ -712,13 +679,13 @@ class DemoCodePanel(wx.Panel):
     def OnRadioButton(self, event):
         radioSelected = event.GetEventObject()
         modSelected = radioSelected.modID
-        if modSelected != self.demoModules.GetActiveID():
-            busy = wx.BusyInfo("Reloading demo module...")
-            self.demoModules.SetActive(modSelected)
+        if modSelected != self.CodeModules.GetActiveID():
+            busy = wx.BusyInfo("Reloading Code module...")
+            self.CodeModules.SetActive(modSelected)
             self.ActiveModuleChanged()
 
     def ReloadDemo(self):
-        if self.demoModules.name != __name__:
+        if self.CodeModules.name != __name__:
             self.mainFrame.RunModule()
 
     def OnCodeModified(self, event):
@@ -742,11 +709,11 @@ class DemoCodePanel(wx.Panel):
         if isUTF8Strict(source):
             try:
                 f.write(source)
-                print("DEBUG: Saved as Unicode")
+                # print("DEBUG: Saved as Unicode")
             finally:
                 f.close()
         else:
-            print("DEBUG: there were problems with source not being Unicode.")
+            # print("DEBUG: there were problems with source not being Unicode.")
             # Attempt to isolate the problematic bytes
             bsource = bytearray(source)
             try:
@@ -772,17 +739,17 @@ class DemoCodePanel(wx.Panel):
             # finally:
             #     f.close()
 
-        # busy = wx.BusyInfo("Reloading demo module...")
-        # self.demoModules.LoadFromFile(modModified, modifiedFilename)
+        # busy = wx.BusyInfo("Reloading Code module...")
+        # self.CodeModules.LoadFromFile(modModified, modifiedFilename)
         #self.ActiveModuleChanged()
 
         #self.mainFrame.SetTreeModified(True)
 
     def OnRestore(self, event): # Handles the "Delete Modified" button
-        modifiedFilename = GetModifiedFilename(self.demoModules.name)
-        self.demoModules.Delete(modModified)
+        modifiedFilename = GetModifiedFilename(self.CodeModules.name)
+        self.CodeModules.Delete(modModified)
         os.unlink(modifiedFilename) # Delete the modified copy
-        busy = wx.BusyInfo("Reloading demo module...")
+        busy = wx.BusyInfo("Reloading Code module...")
 
         self.ActiveModuleChanged()
 
@@ -816,12 +783,12 @@ class DemoCodePanel(wx.Panel):
             paths = dlg.GetPaths()
 
             # self.log.WriteText('You selected %d files:' % len(paths))
-            self.log.write('You selected %d files:' % len(paths))
+            # DEBUG self.log.write('You selected %d files:' % len(paths))
 
-            for path in paths:
+            #for path in paths:
                 # self.log.WriteText('           %s\n' % path)
-                self.log.write('           %s\n' % path)
-
+            #    self.log.write('           %s\n' % path)
+            path = paths[-1]  # just get the last one
             # Open
             f = open(path, "rb")
             try:
@@ -830,7 +797,7 @@ class DemoCodePanel(wx.Panel):
                 f.close()
 
             # self.log.write('%s\n' % source)
-            self.LoadDemoSource(source)  # Just the last file
+            self.LoadSource(source)  # Just the last file
         # Compare this with the debug above; did we change working dirs?
         # self.log.WriteText("CWD: %s\n" % os.getcwd())
         # self.log.write("CWD: %s\n" % os.getcwd())
@@ -911,7 +878,7 @@ def GetDataDir():
 
 def GetModifiedDirectory():
     """
-    Returns the directory where modified versions of the demo files
+    Returns the directory where modified versions of the Code files
     are stored
     """
     return os.path.join(GetDataDir(), "modified")
@@ -919,7 +886,7 @@ def GetModifiedDirectory():
 
 def GetModifiedFilename(name):
     """
-    Returns the filename of the modified version of the specified demo
+    Returns the filename of the modified version of the specified Code
     """
     if not name.endswith(".py"):
         name = name + ".py"
@@ -928,7 +895,7 @@ def GetModifiedFilename(name):
 
 def GetOriginalFilename(name):
     """
-    Returns the filename of the original version of the specified demo
+    Returns the filename of the original version of the specified Code
     """
     if not name.endswith(".py"):
         name = name + ".py"
@@ -938,7 +905,7 @@ def GetOriginalFilename(name):
 
     originalDir = os.getcwd()
     listDir = os.listdir(originalDir)
-    # Loop over the content of the demo directory
+    # Loop over the content of the Code directory
     for item in listDir:
         if not os.path.isdir(item):
             # Not a directory, continue
@@ -953,7 +920,7 @@ def GetOriginalFilename(name):
 
 
 def DoesModifiedExist(name):
-    """Returns whether the specified demo has a modified copy"""
+    """Returns whether the specified Code has a modified copy"""
     if os.path.exists(GetModifiedFilename(name)):
         return True
     else:
@@ -972,11 +939,11 @@ def GetConfig():
 _platformNames = ["wxMSW", "wxGTK", "wxMac"]
 
 
-def main(filepath):
+def main(filepath, frame=None):
     __name__ = 'Editor'
     app = wx.App()
     frame = wx.Frame(None)
-    panel = DemoCodePanel(frame, None, filepath)
+    panel = CodeEditorPanel(frame, None, filepath)
     frame.Show(True)
     app.MainLoop()
 # ----------------------------------------------------------------------------
@@ -988,7 +955,11 @@ if __name__ == '__main__' and __package__ is None:
     from os import sys, path
     sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
     path = None
-    if sys.argv[1]:
-        path = sys.argv[1]
-    main(path)
+    try:
+        if sys.argv[1]:
+            path = sys.argv[1]
+    except IndexError:
+        pass
+    finally:
+        main(path)
 # ----------------------------------------------------------------------------

--- a/src/robotide/ui/actiontriggers.py
+++ b/src/robotide/ui/actiontriggers.py
@@ -189,7 +189,7 @@ class _NameBuilder(object):
 
     def _accelerator_is_free(self, char):
         char = char.upper()
-        if char not in self._accelerators and char != ' ':
+        if char not in self._accelerators and char != u' ':
             self._accelerators.append(char)
             return True
         return False

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -415,9 +415,13 @@ class RideFrame(wx.Frame, RideEventHandler):
 
     def _populate_tree(self):
         self.tree.populate(self._controller)
-        if self._controller.data.directory:
-            self.filemgr.SetPath(self._controller.data.directory)
-            self.filemgr.ExpandPath(self._controller.data.directory)
+        if len(self._controller.data.directory) > 1:
+            self.filemgr.SelectPath(self._controller.data.source)
+            try:
+                self.filemgr.ExpandPath(self._controller.data.source)
+            except Exception:
+                pass
+            self.filemgr.Update()
 
     def OnOpenTestSuite(self, event):
         if not self.check_unsaved_modifications():

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -275,6 +275,16 @@ class RideFrame(wx.Frame, RideEventHandler):
         # MaximizeButton(True).MinimizeButton(True))
         self.actions.register_actions(
             ActionInfoCollection(_menudata, self, self.tree))
+        ###### File explorer pane
+        self.filemgr = wx.GenericDirCtrl(self, -1, size=(200, 225),
+                                         style=wx.DIRCTRL_3D_INTERNAL |
+                                               wx.DIRCTRL_MULTIPLE)
+        self.filemgr.SetMinSize(wx.Size(120, 200))
+        self._mgr.AddPane(self.filemgr,
+                          aui.AuiPaneInfo().Name("file_manager").
+                          Caption("Files").LeftDockable(True).
+                          CloseButton(True))
+
         mb.take_menu_bar_into_use()
         #### self.splitter.SetMinimumPaneSize(100)
         #### self.splitter.SplitVertically(self.tree, self.notebook, 300)
@@ -282,7 +292,6 @@ class RideFrame(wx.Frame, RideEventHandler):
         self.SetIcons(ImageProvider().PROGICONS)
         # tell the manager to "commit" all the changes just made
         self._mgr.Update()
-
 
     def testToolbar(self):
 
@@ -406,6 +415,9 @@ class RideFrame(wx.Frame, RideEventHandler):
 
     def _populate_tree(self):
         self.tree.populate(self._controller)
+        if self._controller.data.directory:
+            self.filemgr.SetPath(self._controller.data.directory)
+            self.filemgr.ExpandPath(self._controller.data.directory)
 
     def OnOpenTestSuite(self, event):
         if not self.check_unsaved_modifications():

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -437,10 +437,13 @@ class RideFrame(wx.Frame, RideEventHandler):
         if ext in robottypes:
             if not self.check_unsaved_modifications():
                 return
-            self.open_suite(path)
-        else:
-            from robotide.editor import customsourceeditor
-            customsourceeditor.main(path)
+            try:
+                self.open_suite(path)
+                return
+            except UserWarning as e:
+                pass
+        from robotide.editor import customsourceeditor
+        customsourceeditor.main(path)
 
     def OnOpenTestSuite(self, event):
         if not self.check_unsaved_modifications():
@@ -448,7 +451,13 @@ class RideFrame(wx.Frame, RideEventHandler):
         path = RobotFilePathDialog(
             self, self._controller, self._application.settings).execute()
         if path:
-            self.open_suite(path)
+            try:
+                self.open_suite(path)
+                return
+            except UserWarning as e:
+                pass
+            from robotide.editor import customsourceeditor
+            customsourceeditor.main(path)
 
     def check_unsaved_modifications(self):
         if self.has_unsaved_changes():
@@ -460,7 +469,9 @@ class RideFrame(wx.Frame, RideEventHandler):
 
     def open_suite(self, path):
         self._controller.update_default_dir(path)
-        self._controller.load_datafile(path, LoadProgressObserver(self))
+        err = self._controller.load_datafile(path, LoadProgressObserver(self))
+        if isinstance(err, UserWarning):
+            raise err
         self._populate_tree()
 
     def refresh_datafile(self, item, event):

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -171,6 +171,7 @@ class RideFrame(wx.Frame, RideEventHandler):
         self.Bind(wx.EVT_SIZE, self.OnSize)
         self.Bind(wx.EVT_MOVE, self.OnMove)
         self.Bind(wx.EVT_MAXIMIZE, self.OnMaximize)
+        self.Bind(wx.EVT_DIRCTRL_FILEACTIVATED, self.OnOpenFile)
         self._subscribe_messages()
         #print("DEBUG: Call register_tools, actions: %s" % self.actions.__repr__())
         if PY2:
@@ -277,8 +278,7 @@ class RideFrame(wx.Frame, RideEventHandler):
             ActionInfoCollection(_menudata, self, self.tree))
         ###### File explorer pane
         self.filemgr = wx.GenericDirCtrl(self, -1, size=(200, 225),
-                                         style=wx.DIRCTRL_3D_INTERNAL |
-                                               wx.DIRCTRL_MULTIPLE)
+                                         style=wx.DIRCTRL_3D_INTERNAL)
         self.filemgr.SetMinSize(wx.Size(120, 200))
         self._mgr.AddPane(self.filemgr,
                           aui.AuiPaneInfo().Name("file_manager").
@@ -422,6 +422,25 @@ class RideFrame(wx.Frame, RideEventHandler):
             except Exception:
                 pass
             self.filemgr.Update()
+
+    def OnOpenFile(self, event):
+        # EVT_DIRCTRL_FILEACTIVATED
+        from os.path import splitext
+        robottypes = self._application.settings.get('robot types', ['robot',
+                                                                    'txt',
+                                                                    'tsv',
+                                                                    'html'])
+        path = self.filemgr.GetFilePath()
+        ext = splitext(path)
+        ext = ext[1].replace('.', '')
+        # print("DEBUG: path %s ext %s" % (path, ext))
+        if ext in robottypes:
+            if not self.check_unsaved_modifications():
+                return
+            self.open_suite(path)
+        else:
+            from robotide.editor import customsourceeditor
+            customsourceeditor.main(path)
 
     def OnOpenTestSuite(self, event):
         if not self.check_unsaved_modifications():


### PR DESCRIPTION
The file manager allows to open in RIDE files with supported file format (`.robot`, `.txt`, `.tsv`, `.html`).
If the format is invalid (not a Robot Framework file), a message is shown and the file opens in the new Source Editor (still under development).
Any other format will open in the Source Editor.
File are opened by double-clicking on them.
After opening a test suite, the file explorer updates to the selected file.