### PR TITLE
 Fixes issue #1904: Reset colors button

### DIFF
--- a/src/robotide/preferences/editor.py
+++ b/src/robotide/preferences/editor.py
@@ -41,7 +41,7 @@ TREE_THRESHOLD = 5
 class PreferenceEditor(wx.Dialog):
     """A dialog for showing the preference panels"""
     def __init__(self, parent, title, preferences, style="auto"):
-        wx.Dialog.__init__(self, parent, wx.ID_ANY, title, size=(800, 620),
+        wx.Dialog.__init__(self, parent, wx.ID_ANY, title, size=(810, 620),
                            style=wx.RESIZE_BORDER | wx.DEFAULT_DIALOG_STYLE)
         self.Bind(wx.EVT_CLOSE, self.OnClose)
         self._current_panel = None


### PR DESCRIPTION
I also did a few other changes:
- Increased the window size by 10 because one of the labels was very close to the margin
- Added color setting for 'Unknown Variable Foreground' because it was missing
- Moved the column for background colors first because it has more elements, otherwise the column for foreground colors would have left a big gap between it and the reset button