### PR TITLE
Fixes issue #1912: Metaclass compatibility

### DIFF
--- a/src/robotide/editor/__init__.py
+++ b/src/robotide/editor/__init__.py
@@ -27,9 +27,6 @@ from .editorcreator import EditorCreator
 
 
 _EDIT = """
-[File]
-&Save | Save current suite or resource | Ctrlcmd-S | ART_FILE_SAVE
-
 [Edit]
 &Undo | Undo last modification | Ctrlcmd-Z
 &Redo | Redo modification | Ctrlcmd-Y

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -77,7 +77,7 @@ def requires_focus(function):
 from robotide.utils.noconflict import classmaker
 
 
-class KeywordEditor(GridEditor, RideEventHandler):
+class KeywordEditor(GridEditor, RideEventHandler, metaclass=classmaker()):
     __metaclass__ = classmaker()
     _no_cell = (-1, -1)
     _popup_menu_shown = False

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -47,6 +47,7 @@ from .editordialogs import UserKeywordNameDialog, ScalarVariableDialog, \
 from .contentassist import ExpandingContentAssistTextCtrl
 from .gridcolorizer import Colorizer
 from robotide.utils import PY3
+from robotide.lib.robot.utils.compat import with_metaclass
 
 if PY3:
     from robotide.utils import basestring, unicode, unichr
@@ -77,8 +78,7 @@ def requires_focus(function):
 from robotide.utils.noconflict import classmaker
 
 
-class KeywordEditor(GridEditor, RideEventHandler, metaclass=classmaker()):
-    __metaclass__ = classmaker()
+class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
     _no_cell = (-1, -1)
     _popup_menu_shown = False
     dirty = property(lambda self: self._controller.dirty)

--- a/src/robotide/editor/listeditor.py
+++ b/src/robotide/editor/listeditor.py
@@ -14,9 +14,9 @@
 #  limitations under the License.
 
 import wx
+from robotide.lib.robot.utils.compat import with_metaclass
 from wx.lib.mixins.listctrl import ListCtrlAutoWidthMixin
 from robotide.controller.ctrlcommands import MoveUp, MoveDown, DeleteItem
-
 from robotide.utils import RideEventHandler
 from robotide.widgets import PopupMenu, PopupMenuItems, ButtonWithHandler, Font
 from robotide.context import ctrl_or_cmd, bind_keys_to_evt_menu, IS_WINDOWS
@@ -145,8 +145,7 @@ class ListEditorBase(wx.Panel):
 from robotide.utils.noconflict import classmaker
 
 
-class ListEditor(ListEditorBase, RideEventHandler, metaclass=classmaker()):
-    __metaclass__ = classmaker()
+class ListEditor(with_metaclass(classmaker(), ListEditorBase, RideEventHandler)):
     pass
 
 class AutoWidthColumnList(wx.ListCtrl, ListCtrlAutoWidthMixin):

--- a/src/robotide/editor/listeditor.py
+++ b/src/robotide/editor/listeditor.py
@@ -145,7 +145,7 @@ class ListEditorBase(wx.Panel):
 from robotide.utils.noconflict import classmaker
 
 
-class ListEditor(ListEditorBase, RideEventHandler):
+class ListEditor(ListEditorBase, RideEventHandler, metaclass=classmaker()):
     __metaclass__ = classmaker()
     pass
 

--- a/src/robotide/editor/settingeditors.py
+++ b/src/robotide/editor/settingeditors.py
@@ -21,7 +21,7 @@ from robotide.controller.ctrlcommands import UpdateVariable, UpdateDocumentation
 from robotide.editor.listeditor import ListEditorBase
 from robotide.publish.messages import RideImportSetting,\
     RideOpenVariableDialog, RideExecuteSpecXmlImport, RideSaving
-from robotide.utils import overrides
+from robotide.utils import overrides, PY3
 from robotide.widgets import ButtonWithHandler, Label, HtmlWindow, PopupMenu,\
     PopupMenuItems, HtmlDialog
 from robotide.publish import PUBLISHER
@@ -36,7 +36,6 @@ from .editordialogs import EditorDialog, DocumentationDialog, MetadataDialog,\
 from .listeditor import ListEditor
 from .popupwindow import HtmlPopupWindow
 from .tags import TagsDisplay
-from robotide.utils import PY3
 if PY3:
     from robotide.utils import basestring
 
@@ -44,7 +43,7 @@ if PY3:
 from robotide.utils.noconflict import classmaker
 
 
-class SettingEditor(wx.Panel, utils.RideEventHandler):
+class SettingEditor(wx.Panel, utils.RideEventHandler, metaclass=classmaker()):
     __metaclass__ = classmaker()
 
     def __init__(self, parent, controller, plugin, tree):

--- a/src/robotide/editor/settingeditors.py
+++ b/src/robotide/editor/settingeditors.py
@@ -27,7 +27,7 @@ from robotide.widgets import ButtonWithHandler, Label, HtmlWindow, PopupMenu,\
 from robotide.publish import PUBLISHER
 from robotide import utils
 from robotide.utils.highlightmatcher import highlight_matcher
-
+from robotide.lib.robot.utils.compat import with_metaclass
 from .formatters import ListToStringFormatter
 from .gridcolorizer import ColorizationSettings
 from .editordialogs import EditorDialog, DocumentationDialog, MetadataDialog,\
@@ -43,8 +43,7 @@ if PY3:
 from robotide.utils.noconflict import classmaker
 
 
-class SettingEditor(wx.Panel, utils.RideEventHandler, metaclass=classmaker()):
-    __metaclass__ = classmaker()
+class SettingEditor(with_metaclass(classmaker(), wx.Panel, utils.RideEventHandler)):
 
     def __init__(self, parent, controller, plugin, tree):
         wx.Panel.__init__(self, parent)

--- a/src/robotide/publish/messages2.py
+++ b/src/robotide/publish/messages2.py
@@ -18,6 +18,7 @@ import inspect
 import sys
 import traceback
 
+from robotide.utils import unicode
 from robotide import utils
 
 from robotide.publish import messagetype

--- a/src/robotide/publish/messages2.py
+++ b/src/robotide/publish/messages2.py
@@ -13,19 +13,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import inspect
 import sys
 import traceback
 
-from robotide.utils import unicode
+
 from robotide import utils
 
 from robotide.publish import messagetype
 from robotide.publish import publisher
+from robotide.lib.robot.utils.compat import with_metaclass
 
 
-class RideMessage(object):
+class RideMessage(with_metaclass(messagetype.messagetype, object)):
     """Base class for all messages sent by RIDE.
 
     :CVariables:
@@ -39,7 +39,7 @@ class RideMessage(object):
         Names of attributes this message provides. These must be given as
         keyword arguments to `__init__` when an instance is created.
     """
-    __metaclass__ = messagetype.messagetype
+
     topic = None  #  DEBUG None
     data = []
 

--- a/src/robotide/publish/messages3.py
+++ b/src/robotide/publish/messages3.py
@@ -207,6 +207,7 @@ class RideNotebookTabChanging(RideMessage):
 
 class RideNotebookTabChanged(RideMessage):
     """Sent after the notebook tab change has completed."""
+    pass
 
 
 class RideSaving(RideMessage):
@@ -224,6 +225,7 @@ class RideSaved(RideMessage):
 
 class RideSaveAll(RideMessage):
     """Sent when user selects ``Save All`` from ``File`` menu or via shortcut."""
+    pass
 
 
 class RideDataDirtyCleared(RideMessage):
@@ -261,6 +263,7 @@ class RideSelectResource(RideMessage):
 
 class RideDataChanged(RideMessage):
     """Base class for all messages notifying that data in model has changed."""
+    pass
 
 
 class RideFileNameChanged(RideDataChanged):
@@ -344,6 +347,7 @@ class RideDataFileSet(RideDataChanged):
 
 class RideUserKeyword(RideDataChanged):
     """Base class for all messages about changes to any user keyword."""
+    pass
 
 
 class RideUserKeywordAdded(RideUserKeyword):

--- a/src/robotide/publish/messages3.py
+++ b/src/robotide/publish/messages3.py
@@ -22,9 +22,10 @@ from robotide import utils
 
 from robotide.publish import messagetype
 from robotide.publish import publisher
+from robotide.lib.robot.utils.compat import with_metaclass
 
 
-class RideMessage(object, metaclass=messagetype.messagetype):
+class RideMessage(with_metaclass(messagetype.messagetype, object)):
     """Base class for all messages sent by RIDE.
 
     :CVariables:

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -138,7 +138,7 @@ class SizeReportCtrl(wx.Control):
         self.Refresh()
 
 
-class RideFrame(wx.Frame, RideEventHandler):
+class RideFrame(wx.Frame, RideEventHandler, metaclass=classmaker()):
     __metaclass__ = classmaker()
 
     def __init__(self, application, controller):

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -17,7 +17,7 @@ import wx
 import wx.lib.agw.aui as aui
 from wx import Icon
 from wx.lib.agw.aui import aui_switcherdialog as ASD
-
+from robotide.lib.robot.utils.compat import with_metaclass
 from robotide.action import ActionInfoCollection, ActionFactory, SeparatorInfo
 from robotide.context import ABOUT_RIDE, SHORTCUT_KEYS
 from robotide.controller.ctrlcommands import SaveFile, SaveAll
@@ -138,8 +138,7 @@ class SizeReportCtrl(wx.Control):
         self.Refresh()
 
 
-class RideFrame(wx.Frame, RideEventHandler, metaclass=classmaker()):
-    __metaclass__ = classmaker()
+class RideFrame(with_metaclass(classmaker(), wx.Frame, RideEventHandler)):
 
     def __init__(self, application, controller):
         size = application.settings.get('mainframe size', (1100, 700))

--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -63,11 +63,12 @@ if wx.VERSION >= (3, 0, 3, ''):
 if IS_WINDOWS:
     _TREE_ARGS['style'] |= wx.TR_EDIT_LABELS
 
-
 # Metaclass fix from http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/
 from robotide.utils.noconflict import classmaker
+
+
 class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl,
-           utils.RideEventHandler):
+           utils.RideEventHandler, metaclass=classmaker()):
     __metaclass__ = classmaker()
 
     _RESOURCES_NODE_LABEL = 'External Resources'

--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -23,6 +23,7 @@ except ImportError:
     from wx import Colour
     TREETEXTCOLOUR = Colour(0xA9, 0xA9, 0xA9)  # wxPython 3.0.2
 
+from robotide.lib.robot.utils.compat import with_metaclass
 from robotide.controller.ui.treecontroller import TreeController, \
     TestSelectionController
 from robotide.context import IS_WINDOWS
@@ -67,10 +68,9 @@ if IS_WINDOWS:
 from robotide.utils.noconflict import classmaker
 
 
-class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl,
-           utils.RideEventHandler, metaclass=classmaker()):
-    __metaclass__ = classmaker()
-
+class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
+                          customtreectrl.CustomTreeCtrl,
+                          utils.RideEventHandler)):
     _RESOURCES_NODE_LABEL = 'External Resources'
 
     def __init__(self, parent, action_registerer, settings=None):

--- a/src/robotide/utils/eventhandler.py
+++ b/src/robotide/utils/eventhandler.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 
 import wx
-
+from robotide.lib.robot.utils.compat import with_metaclass
 
 class eventhandlertype(type):
     def __new__(cls, name, bases, dict):
@@ -34,8 +34,7 @@ class eventhandlertype(type):
         return type.__new__(cls, name, bases, dict)
 
 
-class RideEventHandler(object, metaclass=eventhandlertype):
-    __metaclass__ = eventhandlertype
+class RideEventHandler(with_metaclass(eventhandlertype, object)):
     _SHOWING_MODIFIED_ON_DISK_CONTROLLERS_ = set()
     _SHOWING_REMOVED_ON_DISK_CONTROLLERS_ = set()
 

--- a/src/robotide/utils/eventhandler.py
+++ b/src/robotide/utils/eventhandler.py
@@ -34,7 +34,7 @@ class eventhandlertype(type):
         return type.__new__(cls, name, bases, dict)
 
 
-class RideEventHandler(object):
+class RideEventHandler(object, metaclass=eventhandlertype):
     __metaclass__ = eventhandlertype
     _SHOWING_MODIFIED_ON_DISK_CONTROLLERS_ = set()
     _SHOWING_REMOVED_ON_DISK_CONTROLLERS_ = set()

--- a/src/robotide/utils/noconflict.py
+++ b/src/robotide/utils/noconflict.py
@@ -15,6 +15,7 @@
 
 # Metaclass fix from http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/
 
+from robotide.utils import PY3
 import inspect, types
 try:
     import __builtin__
@@ -33,7 +34,10 @@ def skip_redundant(iterable, skipset=None):
 
 
 def remove_redundant(metaclasses):
-    skipset = set([types.ClassType])
+    if PY3:
+        skipset = set([type(types)])
+    else:
+        skipset = set([types.ClassType])
     for meta in metaclasses: # determines the metaclasses to be skipped
         skipset.update(inspect.getmro(meta)[1:])
     return tuple(skip_redundant(metaclasses, skipset))


### PR DESCRIPTION
The issue was present only on python 3. It was occurring because implemetation for metaclass was changed in python 3. As such, a special solution was needed to be both python 2 and python 3 compatible.