### PR TITLE
Conditioned sizes of Tagboxes and ComboBoxes to be platform specific

### DIFF
--- a/src/robotide/editor/tags.py
+++ b/src/robotide/editor/tags.py
@@ -17,6 +17,7 @@ import wx
 
 from robotide.controller.ctrlcommands import ChangeTag, ClearSetting
 from robotide.controller.tags import ForcedTag, DefaultTag
+from robotide.context import IS_WINDOWS
 
 
 class TagsDisplay(wx.lib.scrolledpanel.ScrolledPanel):
@@ -153,7 +154,8 @@ class TagBox(wx.TextCtrl):
 
     def _get_size(self):
         size = self.GetTextExtent(self.value)
-        return wx.Size(max(size[0]+13, 75), max(size[1]+3, 25))
+        offset = 13 if IS_WINDOWS else 26  # On GTK3 labels are bigger
+        return wx.Size(max(size[0]+offset, 75), max(size[1]+3, 25))
 
     def _colorize(self):
         self.SetForegroundColour(self._properties.foreground_color)

--- a/src/robotide/preferences/widgets.py
+++ b/src/robotide/preferences/widgets.py
@@ -17,6 +17,7 @@ import wx
 import textwrap
 
 from robotide.widgets import HelpLabel, Label, TextField
+from robotide.context import IS_WINDOWS
 
 
 class PreferencesPanel(wx.Panel):
@@ -61,8 +62,9 @@ class PreferencesComboBox(wx.ComboBox):
             The value 72 is there for 2 digits numeric lists, for
             IntegerPreferenceComboBox.
         """
+        fact = 9 if IS_WINDOWS else 18  # On GTK3 labels are bigger
         if choices:
-            return wx.Size(max(max(len(str(s)) for s in choices)*9, 72), 20)
+            return wx.Size(max(max(len(str(s)) for s in choices)*fact, 72), 20)
         return wx.DefaultSize
 
     def OnSelect(self, event):


### PR DESCRIPTION
On linux (with gtk3) some sizes needed to be bigger.

In PR #1905 I made a factor related to this smaller, so on linux not all text was being shown.