### PR TITLE
Fixes permission issue

### DIFF
--- a/src/robotide/controller/filecontrollers.py
+++ b/src/robotide/controller/filecontrollers.py
@@ -116,6 +116,11 @@ class _DataController(_BaseController, WithUndoRedoStacks, WithNamespace):
         self.set_datafile(data)
         self.dirty = False
         self.children = self._children(data)
+        # Filename needs to be set when creating a new datafile
+        if hasattr(self.data, 'initfile'):
+            self.filename = self.data.initfile
+        else:
+            self.filename = self.data.source
 
     def set_datafile(self, datafile):
         self.data = datafile


### PR DESCRIPTION
Filename value needed to be initialized, so that RIDE uses the file's path (instead of the directory path).

Fixes #1869 and #1818.