### PR TITLE
#1878 Fixes conflict generated by TextEditor shortcuts

### DIFF
--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -568,9 +568,9 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
         keycode, control_down = event.GetKeyCode(), event.CmdDown()
         # print("DEBUG: key pressed " + str(keycode) + " + " +  str(control_down))
         # event.Skip()  # DEBUG seen this skip as soon as possible
-        if keycode != wx.WXK_SPACE and control_down or event.AltDown():  # keycode == wx.WXK_CONTROL
+        if keycode != wx.WXK_SPACE and (control_down or event.AltDown()):  # keycode == wx.WXK_CONTROL
             self.show_cell_information()
-        if keycode == wx.WXK_SPACE and (control_down or event.AltDown()):  # Avoid Mac CMD
+        elif keycode == wx.WXK_SPACE and (control_down or event.AltDown()):  # Avoid Mac CMD
             self._open_cell_editor_with_content_assist()
         elif keycode == ord('C') and control_down:
             # print("DEBUG: captured Control-C\n")

--- a/src/robotide/editor/texteditor.py
+++ b/src/robotide/editor/texteditor.py
@@ -76,8 +76,9 @@ class TextEditorPlugin(Plugin, TreeAwarePluginMixin):
         self.subscribe(self.OnTreeSelection, RideTreeSelection)
         self.subscribe(self.OnDataChanged, RideMessage)
         self.subscribe(self.OnTabChange, RideNotebookTabChanging)
-        self._register_shortcuts()
-        self._open()
+        if self._editor.is_focused():
+            self._register_shortcuts()
+            self._open()
 
     def _register_shortcuts(self):
         def focused(func):
@@ -163,12 +164,13 @@ class TextEditorPlugin(Plugin, TreeAwarePluginMixin):
 
     def OnTabChange(self, message):
         if message.newtab == self.title:
+            self._register_shortcuts()
             self._open()
             self._editor.set_editor_caret_position()
         elif message.oldtab == self.title:
             # print("DEBUG: OnTabChange move to another from Text Editor.")
-            # event.Skip()
             self._editor.remove_and_store_state()
+            self.unregister_actions()
 
     def OnTabChanged(self, event):
         self._show_editor()


### PR DESCRIPTION
I've set it so that `TextEditor` shortcuts are unregistered if tab is not selected.

I've also fixed a small issue that I noticed in kweditor. 