### PR TITLE
#2009 Fixes tests getting remove from tree when moving them

### DIFF
--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -233,6 +233,7 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
             self._animctrl.Animation.Destroy()
             self._animctrl.Destroy()
             self._animctrl = None
+            self.DeleteItemWindow(node)
         if wx.VERSION >= (3, 0, 3, '') and img_index in (RUNNING_IMAGE_INDEX, PAUSED_IMAGE_INDEX):
             from wx.adv import Animation, AnimationCtrl
             import os


### PR DESCRIPTION
When `_set_icon_from_execution_results()` is called it sets item window to `AnimationCtrl()`, but it isn't deleted after `AnimationCtrl()` is destroyed. This was causing an error when moving test in tree.