### PR TITLE
Fixes keyword autocompletion in Text Editor

### DIFF
--- a/src/robotide/editor/texteditor.py
+++ b/src/robotide/editor/texteditor.py
@@ -171,6 +171,7 @@ class TextEditorPlugin(Plugin, TreeAwarePluginMixin):
             # print("DEBUG: OnTabChange move to another from Text Editor.")
             self._editor.remove_and_store_state()
             self.unregister_actions()
+            self._editor_component.save()
 
     def OnTabChanged(self, event):
         self._show_editor()


### PR DESCRIPTION
Steps to reproduce issue:

1. Type a keyword start in Text Editor and press Ctrl-Space, select from list
2. Go to Grid Editor, and Ctrl-Space and select from list with Arrow-down and then Enter,
3. The keyword is not saved to cell, and there is a redraw of the Grid.