### PR TITLE
Fixed some really old issues in testsearch dialog

### DIFF
--- a/src/robotide/searchtests/dialogsearchtests.py
+++ b/src/robotide/searchtests/dialogsearchtests.py
@@ -160,6 +160,7 @@ class TestsDialog(Dialog):
         line1.Add(add_to_selection_button)
         panel.Sizer.Add(line1, 0, wx.ALL, 3)
         panel.Sizer.Add(self._add_info_text(panel, "Find matches by test name, documentation and/or tag."), 0, wx.ALL, 3)
+        panel.Sizer.Layout()
 
     def _horizontal_sizer(self):
         return wx.BoxSizer(wx.HORIZONTAL)
@@ -175,8 +176,9 @@ class TestsDialog(Dialog):
         sizer.Add(self._search_control, 0, wx.ALL, 3)
 
     def _select_text_search_result(self, idx):
-        for listener in self._selection_listeners:
-            listener(self.tests[idx])
+        if idx != -1:
+            for listener in self._selection_listeners:
+                listener(self.tests[idx])
 
     def _select_tag_search_result(self, idx):
         for listener in self._selection_listeners:


### PR DESCRIPTION
When you open it there is a black square on the search box.

![image](https://user-images.githubusercontent.com/39315668/69020778-615ad380-09be-11ea-990c-3c7dcea9243c.png)

Also, if you click on the listctrl when there are no results an error occurs (RIDE can sometimes even crash from this).