### PR TITLE
Added zoom factor to settings.cfg so that changes persist in Text Editor

### DIFF
--- a/src/robotide/editor/texteditor.py
+++ b/src/robotide/editor/texteditor.py
@@ -693,7 +693,7 @@ class RobotDataEditor(stc.StyledTextCtrl):
     def calc_margin_width(self):
         style = stc.STC_STYLE_LINENUMBER
         width = self.TextWidth(style, str(self.GetLineCount()))
-        return width + self.TextWidth(style, "12")  # return with offset
+        return width + self.TextWidth(style, "1")
 
     def get_selected_or_near_text(self):
         # First get selected text
@@ -751,6 +751,9 @@ class RobotStylizer(object):
     def _font_face(self):
         return self.settings['Text Edit'].get('font face', 'Courier New')
 
+    def _zoom_factor(self):
+        return self.settings['Text Edit'].get('zoom factor', 0)
+
     def _set_styles(self):
         color_settings = self.settings.get_without_default('Text Edit')
         background = color_settings.get('background', '#FFFFFF')
@@ -807,6 +810,7 @@ class RobotStylizer(object):
             self.editor.StyleSetSpec(0, self._get_style_string(back=background,
                                                                fore=foreground))
         self.editor.StyleSetBackground(wx.stc.STC_STYLE_DEFAULT, background)
+        self.editor.SetZoom(self._zoom_factor())
         self.editor.Refresh()
 
     def _get_word_and_length(self, current_position):

--- a/src/robotide/editor/texteditor.py
+++ b/src/robotide/editor/texteditor.py
@@ -662,14 +662,15 @@ class SourceEditor(wx.Panel):
 
 
 class RobotDataEditor(stc.StyledTextCtrl):
+    margin = 1
 
     def __init__(self, parent):
         stc.StyledTextCtrl.__init__(self, parent)
-        self.SetMarginType(0, stc.STC_MARGIN_NUMBER)
-        self.SetMarginWidth(0, self.TextWidth(stc.STC_STYLE_LINENUMBER, '1234'))
-        self.SetReadOnly(True)
+        self.SetMarginType(self.margin, stc.STC_MARGIN_NUMBER)
         self.SetLexer(stc.STC_LEX_CONTAINER)
+        self.SetReadOnly(True)
         self.Bind(stc.EVT_STC_STYLENEEDED, self.OnStyle)
+        self.Bind(stc.EVT_STC_ZOOM, self.OnZoom)
         self.stylizer = RobotStylizer(self, parent._parent._app.settings)
 
     def set_text(self, text):
@@ -677,6 +678,7 @@ class RobotDataEditor(stc.StyledTextCtrl):
         self.SetText(text)
         self.stylizer.stylize()
         self.EmptyUndoBuffer()
+        self.SetMarginWidth(self.margin, self.calc_margin_width())
 
     @property
     def utf8_text(self):
@@ -684,6 +686,14 @@ class RobotDataEditor(stc.StyledTextCtrl):
 
     def OnStyle(self, event):
         self.stylizer.stylize()
+
+    def OnZoom(self, event):
+        self.SetMarginWidth(self.margin, self.calc_margin_width())
+
+    def calc_margin_width(self):
+        style = stc.STC_STYLE_LINENUMBER
+        width = self.TextWidth(style, str(self.GetLineCount()))
+        return width + self.TextWidth(style, "12")  # return with offset
 
     def get_selected_or_near_text(self):
         # First get selected text

--- a/src/robotide/editor/texteditor.py
+++ b/src/robotide/editor/texteditor.py
@@ -666,12 +666,13 @@ class RobotDataEditor(stc.StyledTextCtrl):
 
     def __init__(self, parent):
         stc.StyledTextCtrl.__init__(self, parent)
+        self._settings = parent._parent._app.settings
         self.SetMarginType(self.margin, stc.STC_MARGIN_NUMBER)
         self.SetLexer(stc.STC_LEX_CONTAINER)
         self.SetReadOnly(True)
         self.Bind(stc.EVT_STC_STYLENEEDED, self.OnStyle)
         self.Bind(stc.EVT_STC_ZOOM, self.OnZoom)
-        self.stylizer = RobotStylizer(self, parent._parent._app.settings)
+        self.stylizer = RobotStylizer(self, self._settings)
 
     def set_text(self, text):
         self.SetReadOnly(False)
@@ -689,6 +690,13 @@ class RobotDataEditor(stc.StyledTextCtrl):
 
     def OnZoom(self, event):
         self.SetMarginWidth(self.margin, self.calc_margin_width())
+        self._set_zoom()
+
+    def _set_zoom(self):
+        new = self.GetZoom()
+        old = self._settings['Text Edit'].get('zoom factor', 0)
+        if new != old:
+            self._settings['Text Edit'].set('zoom factor', new)
 
     def calc_margin_width(self):
         style = stc.STC_STYLE_LINENUMBER

--- a/src/robotide/preferences/configobj.py
+++ b/src/robotide/preferences/configobj.py
@@ -233,6 +233,9 @@ class Builder(object):
         # print("DEBUG: build_Num v=%s \n" % compiler.literal_eval(o))
         return compiler.literal_eval(o)
 
+    def build_UnaryOp(self, o):
+        return compiler.literal_eval(o)
+
     def build_NameConstant(self, o):
         return self.build_Name(o)
 
@@ -1710,10 +1713,10 @@ class ConfigObj(Section):
                             # print("DEBUG: _parser exception at unrepr? error: %s\n", str(e))
                             if isinstance(e, UnknownType):
                                 msg = 'Unknown name or type in value at line %s.'
-                            # else:
-                            #    msg = 'Parse error in value at line %s.'
-                            #self._handle_error(msg, UnreprError, infile,
-                            #    cur_index)
+                            else:
+                                msg = 'Parse error in value at line %s.'
+                            print(str(UnreprError), msg % cur_index)
+                            #self._handle_error(msg, UnreprError, infile,cur_index)
                             continue
                     else:
                         # extract comment and lists

--- a/src/robotide/preferences/editors.py
+++ b/src/robotide/preferences/editors.py
@@ -103,6 +103,11 @@ class EditorPreferences(widgets.PreferencesPanel):
             [str(i) for i in range(8, 16)])
         sizer = wx.FlexGridSizer(rows=3, cols=2, vgap=10, hgap=30)
         sizer.AddMany([f.label(self), f.chooser(self)])
+        if 'zoom factor' in self._settings:
+            z = widgets.IntegerChoiceEditor(
+                self._settings, 'zoom factor', 'Zoom Factor',
+                [str(i) for i in range(-10, 21, 2)])
+            sizer.AddMany([z.label(self), z.chooser(self)])
         if 'fixed font' in self._settings:
             sizer.AddMany(widgets.boolean_editor(
                 self, self._settings, 'fixed font', 'Use fixed width font'))

--- a/src/robotide/preferences/editors.py
+++ b/src/robotide/preferences/editors.py
@@ -105,9 +105,8 @@ class EditorPreferences(widgets.PreferencesPanel):
         sizer.AddMany([f.label(self), f.chooser(self)])
         fixed_font = False
         if 'zoom factor' in self._settings:
-            z = widgets.IntegerChoiceEditor(
-                self._settings, 'zoom factor', 'Zoom Factor',
-                [str(i) for i in range(-10, 21, 2)])
+            z = widgets.SpinChoiceEditor(
+                self._settings, 'zoom factor', 'Zoom Factor', (-10, 20))
             sizer.AddMany([z.label(self), z.chooser(self)])
         if 'fixed font' in self._settings:
             sizer.AddMany(widgets.boolean_editor(

--- a/src/robotide/preferences/settings.cfg
+++ b/src/robotide/preferences/settings.cfg
@@ -24,6 +24,7 @@ default file format = 'robot'
 
 [Text Edit]
 font size = 10
+zoom factor = 0
 font face = 'Courier New'
 argument = '#bb8844'
 comment = 'black'


### PR DESCRIPTION
I've chosen to add zoom factor as a separate input in Text Editor preferences. The original issue mentioned that it should be added to font size, but I thought that would just create confusion. This way the user can be aware of its value.

I've also made the margin resizable, so that it adapts to the new font size/zoom.

The new function `build_UnaryOp` is so that configobj can handle variable from settings.cfg that have negative values. I had to fix this too because zoom factor range is [-10, 20]. 

Fixes #1298