### PR TITLE
Fixed emoji index error

### DIFF
--- a/src/robotide/editor/cellrenderer.py
+++ b/src/robotide/editor/cellrenderer.py
@@ -41,7 +41,7 @@ class CellRenderer(wx.grid.GridCellRenderer):
             start = 0
             startIdx = 0
             spcIdx = -1
-            while idx < len(pte):
+            while idx < len(line):
                 # remember the last seen space
                 if line[idx] == ' ':
                     spcIdx = idx


### PR DESCRIPTION
Issue originates from `_wordwrap()`. The line `pte = dc.GetPartialTextExtents(line)` returns a list of values, where each value represents an emoji. For emoji it returns 2 values instead of one, so it throws an index error when the line is parsed character by character.

Fixed emojis for issue #2043