### PR TITLE
Removed ellipsize from tree

### DIFF
--- a/src/robotide/ui/tree.py
+++ b/src/robotide/ui/tree.py
@@ -58,8 +58,7 @@ if wx.VERSION >= (2, 8, 11, ''): # wx.VERSION_STRING >= '2.8.11.0':
         customtreectrl.TR_EDIT_LABELS
 
 if wx.VERSION >= (3, 0, 3, ''):
-    _TREE_ARGS['agwStyle'] |= customtreectrl.TR_ELLIPSIZE_LONG_ITEMS | \
-        customtreectrl.TR_TOOLTIP_ON_LONG_ITEMS
+    _TREE_ARGS['agwStyle'] |= customtreectrl.TR_TOOLTIP_ON_LONG_ITEMS
 
 if IS_WINDOWS:
     _TREE_ARGS['style'] |= wx.TR_EDIT_LABELS


### PR DESCRIPTION
I think it would be better if we remove this, since it doesn't work very well. 

If you try to edit a test case while the ellipsize is visible, the horizontal scrollbar from tree will move and cause ellipsize position to be calculated incorrectly for all labels.

It's a [wx bug](https://github.com/wxWidgets/Phoenix/issues/1395), so we can't do anything about it.