### PR TITLE
Makes Text Editor read-only if file is read-only. Visual hint is back…

### DIFF
--- a/doc/other/example_maven_runner/pom.xml
+++ b/doc/other/example_maven_runner/pom.xml
@@ -20,7 +20,7 @@
 					<plugin>
 						<groupId>org.robotframework</groupId>
 						<artifactId>robotframework-maven-plugin</artifactId>
-						<version>1.5.1</version>
+						<version>1.5.2</version>
 						<executions>
 							<execution>
 								<phase>integration-test</phase>
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>com.github.hi-fi</groupId>
 			<artifactId>robotframework-seleniumlibrary</artifactId>
-			<version>3.141.59.2</version>
+			<version>3.141.59.26535</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
…ground color change.

Not perfect, because changing background color on Preferences, when on Read-Only file, does not apply read-only. 
Correct on Tab change, Open file and select from tree.

Fixes #987 