### PR TITLE
Fixed SelectAll issue in Grid Editor, RIDE Log and Parser Log

### DIFF
--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -578,65 +578,57 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
         self.MoveCursorDown(event.ShiftDown())
 
     def OnKeyDown(self, event):
-        """ Fixed on 4.0.0a3
-        if wx.VERSION >= (3, 0, 3, ''):  # DEBUG wxPhoenix
-            _iscelleditcontrolshown = self.IsCellEditControlEnabled()
+        keycode = event.GetKeyCode()
+
+        if event.ControlDown():
+            if event.ShiftDown():
+                if keycode == ord('I'):
+                    self.OnInsertCells()
+                elif keycode == ord('J'):
+                    self.OnJsonEditor(event)
+                elif keycode == ord('D'):
+                    self.OnDeleteCells()
+            else:
+                if keycode == wx.WXK_SPACE:
+                    self._open_cell_editor_with_content_assist()
+                elif keycode == ord('C'):
+                    self.OnCopy(event)
+                elif keycode == ord('X'):
+                    self.OnCut(event)
+                elif keycode == ord('V'):
+                    self.OnPaste(event)
+                elif keycode == ord('Z'):
+                    self.OnUndo(event)
+                elif keycode == ord('A'):
+                    self.OnSelectAll(event)
+                elif keycode == ord('B'):
+                    self._navigate_to_matching_user_keyword(
+                        self.GetGridCursorRow(), self.GetGridCursorCol())
+                elif keycode == ord('F'):
+                    if not self.has_focus():
+                        self.SetFocus() # Avoiding Search field on Text Edit
+                elif keycode in (ord('1'), ord('2'), ord('5')):
+                    self._open_cell_editor_and_execute_variable_creator(
+                        list_variable=(keycode == ord('2')),
+                        dict_variable=(keycode == ord('5')))
+                else:
+                    self.show_cell_information()
+        elif event.AltDown():
+            if keycode == wx.WXK_SPACE:
+                self._open_cell_editor_with_content_assist() # Mac CMD
+            elif keycode in [wx.WXK_DOWN, wx.WXK_UP]:
+                self._skip_except_on_mac(event)
+                self._move_rows(keycode)
+            elif keycode == wx.WXK_RETURN:
+                self._move_cursor_down(event)
         else:
-        """
-        _iscelleditcontrolshown = self.IsCellEditControlShown()
-
-        keycode, control_down = event.GetKeyCode(), event.ControlDown()
-        # print("DEBUG: key pressed " + str(keycode) + " + " +  str(control_down))
-
-        if keycode == wx.WXK_SPACE and (control_down or event.AltDown()):  # Avoid Mac CMD
-            self._open_cell_editor_with_content_assist()
-        elif keycode == ord('C') and control_down:
-            # print("DEBUG: captured Control-C\n")
-            self.OnCopy(event)
-        elif keycode == ord('X') and control_down:
-            self.OnCut(event)
-        elif keycode == ord('V') and control_down:
-            self.OnPaste(event)
-        elif keycode == ord('Z') and control_down:
-            self.OnUndo(event)
-        elif keycode == ord('A') and control_down:
-            self.OnSelectAll(event)
-        elif keycode == ord('F') and control_down:
-            # print("DEBUG: captured Control-F\n")
-            if not self.has_focus():
-                self.SetFocus()  # DEBUG Avoiding Search field on Text Edit
-        elif event.AltDown() and keycode in [wx.WXK_DOWN, wx.WXK_UP]:
-            # print("DEBUG: Alt-Move %s" % self._counter)
-            self._skip_except_on_mac(event)
-            self._move_rows(keycode)
-        elif event.AltDown() and keycode == wx.WXK_RETURN:
-            self._move_cursor_down(event)
-            # event.Skip()
-        elif keycode == wx.WXK_WINDOWS_MENU:
-            self.OnCellRightClick(event)
-        elif keycode in [wx.WXK_RETURN, wx.WXK_BACK]:
-            if _iscelleditcontrolshown:
+            if keycode == wx.WXK_WINDOWS_MENU:
+                self.OnCellRightClick(event)
+            elif keycode in [wx.WXK_RETURN, wx.WXK_BACK]:
                 self.save()
-            self._move_grid_cursor(event, keycode)
-            # event.Skip()
-        elif control_down and not event.AltDown() and \
-                keycode in (ord('1'), ord('2'), ord('5')):
-            self._open_cell_editor_and_execute_variable_creator(
-                list_variable=(keycode == ord('2')),
-                dict_variable=(keycode == ord('5')))
-        elif control_down and event.ShiftDown() and keycode == ord('I'):
-            self.OnInsertCells()
-        elif control_down and event.ShiftDown() and keycode == ord('J'):
-            self.OnJsonEditor(event)
-        elif control_down and event.ShiftDown() and keycode == ord('D'):
-            self.OnDeleteCells()
-        elif control_down and keycode == ord('B'):
-            self._navigate_to_matching_user_keyword(
-                self.GetGridCursorRow(), self.GetGridCursorCol())
-        elif keycode != wx.WXK_SPACE and control_down:
-            self.show_cell_information()
-        else:
-            event.Skip()
+                self._move_grid_cursor(event, keycode)
+            else:
+                event.Skip()
 
     def OnGoToDefinition(self, event):
         self._navigate_to_matching_user_keyword(

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -587,10 +587,8 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
 
         keycode, control_down = event.GetKeyCode(), event.ControlDown()
         # print("DEBUG: key pressed " + str(keycode) + " + " +  str(control_down))
-        # event.Skip()  # DEBUG seen this skip as soon as possible
-        if keycode != wx.WXK_SPACE and control_down:  # keycode == wx.WXK_CONTROL  or event.AltDown()
-            self.show_cell_information()
-        elif keycode == wx.WXK_SPACE and (control_down or event.AltDown()):  # Avoid Mac CMD
+
+        if keycode == wx.WXK_SPACE and (control_down or event.AltDown()):  # Avoid Mac CMD
             self._open_cell_editor_with_content_assist()
         elif keycode == ord('C') and control_down:
             # print("DEBUG: captured Control-C\n")
@@ -635,6 +633,8 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
         elif control_down and keycode == ord('B'):
             self._navigate_to_matching_user_keyword(
                 self.GetGridCursorRow(), self.GetGridCursorCol())
+        elif keycode != wx.WXK_SPACE and control_down:
+            self.show_cell_information()
         else:
             event.Skip()
 

--- a/src/robotide/log/log.py
+++ b/src/robotide/log/log.py
@@ -90,8 +90,8 @@ class LogPlugin(Plugin):
         self._log.append(log_event)
         if self._panel:
             self._panel.update_log()
-     
-        if self.log_to_console:       print("".format(_message_to_string(log_event))) # >> sys.stdout, _message_to_string(log_event)
+        if self.log_to_console:
+            print("".format(_message_to_string(log_event))) # >> sys.stdout, _message_to_string(log_event)
         if self.log_to_file:
             self._logfile.write(_message_to_string(log_event))
             self._outfile.flush()
@@ -106,7 +106,6 @@ class LogPlugin(Plugin):
             self._panel.update_log()
         else:
             self.notebook.show_tab(self._panel)
-        print(self.is_focused())
         if self.is_focused():
             self._register_shortcuts()
 
@@ -163,4 +162,4 @@ class _LogWindow(wx.Panel):
         pass
 
     def SelectAll(self):
-        pass
+        self._output.SetSelection(-1, -1)

--- a/src/robotide/log/log.py
+++ b/src/robotide/log/log.py
@@ -22,7 +22,7 @@ import glob
 import sys
 import io
 
-from robotide.pluginapi import Plugin, ActionInfo, RideLog, RideNotebookTabChanging
+from robotide.pluginapi import Plugin, ActionInfo, RideLog
 from robotide import widgets
 from robotide import context
 from robotide.utils import PY2
@@ -36,7 +36,6 @@ def _message_to_string(msg):
 
 class LogPlugin(Plugin):
     """Viewer for internal log messages."""
-    title = 'RIDE Log'
 
     def __init__(self, app):
         Plugin.__init__(self, app, default_settings={
@@ -73,7 +72,6 @@ class LogPlugin(Plugin):
     def enable(self):
         self._create_menu()
         self.subscribe(self._log_message, RideLog)
-        self.subscribe(self.OnTabChange, RideNotebookTabChanging)
 
     def disable(self):
         self.unsubscribe_all()
@@ -106,30 +104,15 @@ class LogPlugin(Plugin):
             self._panel.update_log()
         else:
             self.notebook.show_tab(self._panel)
-        if self.is_focused():
-            self._register_shortcuts()
-
-    def OnTabChange(self, message):
-        if message.newtab == self.title:
-            self._register_shortcuts()
-        elif message.oldtab == self.title:
-            self.unregister_actions()
-
-    def is_focused(self):
-        return self.notebook.current_page_title == self.title
-
-    def _register_shortcuts(self):
-        self.register_shortcut('CtrlCmd-C', lambda e: self._panel.Copy())
-        self.register_shortcut('CtrlCmd-A', lambda e: self._panel.SelectAll())
 
 
 class _LogWindow(wx.Panel):
 
-    def __init__(self, notebook, log, title='RIDE Log'):
+    def __init__(self, notebook, log):
         wx.Panel.__init__(self, notebook)
         self._output = wx.TextCtrl(self, style=wx.TE_READONLY | wx.TE_MULTILINE)
+        self._output.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
         self._log = log
-        self._title = title
         self._add_to_notebook(notebook)
         self.SetFont(widgets.Font().fixed_log)
         self.Bind(wx.EVT_SIZE, self.OnSize)
@@ -139,7 +122,7 @@ class _LogWindow(wx.Panel):
         self.Sizer.add_expanding(self._output)
 
     def _add_to_notebook(self, notebook):
-        notebook.add_tab(self, self._title, allow_closing=True)
+        notebook.add_tab(self, 'RIDE Log', allow_closing=True)
         notebook.show_tab(self)
         self._output.SetSize(self.Size)
 
@@ -158,8 +141,19 @@ class _LogWindow(wx.Panel):
     def OnSize(self, evt):
         self._output.SetSize(self.Size)
 
+    def OnKeyDown(self, event):
+        keycode = event.GetKeyCode()
+
+        if event.ControlDown():
+            if keycode == ord('C'):
+                self.Copy()
+            elif keycode == ord('A'):
+                self.SelectAll()
+        else:
+            event.Skip()
+
     def Copy(self):
-        pass
+        self._output.Copy()
 
     def SelectAll(self):
         self._output.SetSelection(-1, -1)

--- a/src/robotide/log/log.py
+++ b/src/robotide/log/log.py
@@ -102,6 +102,7 @@ class LogPlugin(Plugin):
         if not self._panel:
             self._panel = _LogWindow(self.notebook, self._log)
             self._panel.update_log()
+            self.register_shortcut('CtrlCmd-C', lambda e: self._panel.Copy())
         else:
             self.notebook.show_tab(self._panel)
 
@@ -144,16 +145,13 @@ class _LogWindow(wx.Panel):
     def OnKeyDown(self, event):
         keycode = event.GetKeyCode()
 
-        if event.ControlDown():
-            if keycode == ord('C'):
-                self.Copy()
-            elif keycode == ord('A'):
-                self.SelectAll()
+        if event.ControlDown() and keycode == ord('A'):
+            self.SelectAll()
         else:
             event.Skip()
 
     def Copy(self):
-        self._output.Copy()
+        pass
 
     def SelectAll(self):
         self._output.SetSelection(-1, -1)

--- a/src/robotide/parserlog/parserlog.py
+++ b/src/robotide/parserlog/parserlog.py
@@ -100,6 +100,7 @@ class ParserLogPlugin(Plugin):
             self._panel = _LogWindow(self.notebook, self._log)
             self.notebook.SetPageTextColour(self.notebook.GetPageCount()-1, wx.Colour(255, 165, 0))
             self._panel.update_log()
+            self.register_shortcut('CtrlCmd-C', lambda e: self._panel.Copy())
         if show_tab:
             self.notebook.show_tab(self._panel)
 
@@ -142,16 +143,13 @@ class _LogWindow(wx.Panel):
     def OnKeyDown(self, event):
         keycode = event.GetKeyCode()
 
-        if event.ControlDown():
-            if keycode == ord('C'):
-                self.Copy()
-            elif keycode == ord('A'):
-                self.SelectAll()
+        if event.ControlDown() and keycode == ord('A'):
+            self.SelectAll()
         else:
             event.Skip()
 
     def Copy(self):
-        self._output.Copy()
+        pass
 
     def SelectAll(self):
         self._output.SetSelection(-1, -1)

--- a/src/robotide/parserlog/parserlog.py
+++ b/src/robotide/parserlog/parserlog.py
@@ -111,14 +111,12 @@ class ParserLogPlugin(Plugin):
         if message.newtab == self.title:
             self._register_shortcuts()
         elif message.oldtab == self.title:
-            print('self.unregister_actions()')
             self.unregister_actions()
 
     def is_focused(self):
         return self.notebook.current_page_title == self.title
 
     def _register_shortcuts(self):
-        print('self._register_shortcuts()')
         self.register_shortcut('CtrlCmd-C', lambda e: self._panel.Copy())
         self.register_shortcut('CtrlCmd-A', lambda e: self._panel.SelectAll())
 
@@ -162,4 +160,4 @@ class _LogWindow(wx.Panel):
         pass
 
     def SelectAll(self):
-        pass
+        self._output.SetSelection(-1, -1)

--- a/src/robotide/parserlog/parserlog.py
+++ b/src/robotide/parserlog/parserlog.py
@@ -21,7 +21,7 @@ import glob
 import sys
 import io
 
-from robotide.pluginapi import Plugin, ActionInfo, RideParserLogMessage
+from robotide.pluginapi import Plugin, ActionInfo, RideParserLogMessage, RideNotebookTabChanging
 from robotide import widgets
 from robotide import context
 
@@ -32,6 +32,7 @@ def _message_to_string(msg):
 
 class ParserLogPlugin(Plugin):
     """Viewer for internal log messages."""
+    title = 'Parser Log'
 
     def __init__(self, app):
         Plugin.__init__(self, app, default_settings={
@@ -68,6 +69,7 @@ class ParserLogPlugin(Plugin):
     def enable(self):
         self._create_menu()
         self.subscribe(self._log_message, RideParserLogMessage)
+        self.subscribe(self.OnTabChange, RideNotebookTabChanging)
 
     def disable(self):
         self.unsubscribe_all()
@@ -97,29 +99,44 @@ class ParserLogPlugin(Plugin):
 
     def OnViewLog(self, event, show_tab=True):
         if not self._panel:
-            self._panel = _LogWindow(self.notebook, self._log)
+            self._panel = _LogWindow(self.notebook, self._log, self.title)
             self.notebook.SetPageTextColour(self.notebook.GetPageCount()-1, wx.Colour(255, 165, 0))
             self._panel.update_log()
-            self.register_shortcut('CtrlCmd-C', lambda e: self._panel.Copy())
-            self.register_shortcut(
-                 'CtrlCmd-A', lambda e: self._panel.SelectAll())
         if show_tab:
             self.notebook.show_tab(self._panel)
+        if self.is_focused():
+            self._register_shortcuts()
+
+    def OnTabChange(self, message):
+        if message.newtab == self.title:
+            self._register_shortcuts()
+        elif message.oldtab == self.title:
+            print('self.unregister_actions()')
+            self.unregister_actions()
+
+    def is_focused(self):
+        return self.notebook.current_page_title == self.title
+
+    def _register_shortcuts(self):
+        print('self._register_shortcuts()')
+        self.register_shortcut('CtrlCmd-C', lambda e: self._panel.Copy())
+        self.register_shortcut('CtrlCmd-A', lambda e: self._panel.SelectAll())
 
 
 class _LogWindow(wx.Panel):
 
-    def __init__(self, notebook, log):
+    def __init__(self, notebook, log, title='Parser Log'):
         wx.Panel.__init__(self, notebook)
         self._output = wx.TextCtrl(self, style=wx.TE_READONLY | wx.TE_MULTILINE)
         self._log = log
         self._notebook = notebook
+        self._title = title
         self._add_to_notebook(notebook)
         self.SetFont(widgets.Font().fixed_log)
         self.Bind(wx.EVT_SIZE, self.OnSize)
 
     def _add_to_notebook(self, notebook):
-        notebook.add_tab(self, 'Parser Log', allow_closing=True)
+        notebook.add_tab(self, self._title, allow_closing=True)
         self._output.SetSize(self.Size)
 
     def close(self, notebook):


### PR DESCRIPTION
Fixes #2084

Issue stems from the order in which the shortcut conditions are called in kweditor. Additionally, there is a conflict between RIDE and Parser Log tab shortcuts.

Changes:
- improved `if` case structure in `OnKeyDown`  (functionality should be the same or better)
- made RIDE and Parser Log tabs to unregister their shortcuts when they're not selected
- updated code so that `Select All` works in RIDE and Parser Log tabs (wasn't implemented)

Please check to see that shortcuts work. On MacOS there might be some additional conflicts between shortcuts from Grid Editor and Text Editor, so make sure to check shortcuts both when Text Editor is disabled and enabled. Leave a message if you find any discrepancies.

Sorry it took so long, I've been busy with other stuff and kinda forgot.