### PR TITLE
Fixed focus issue when using F2 to edit grid cell

### DIFF
--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -573,6 +573,9 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
             elif keycode in [wx.WXK_RETURN, wx.WXK_BACK]:
                 self.save()
                 self._move_grid_cursor(event, keycode)
+            elif keycode == wx.WXK_F2:
+                celleditor = self._open_cell_editor()
+                celleditor._tc.SetFocus()
             else:
                 event.Skip()
 
@@ -643,23 +646,21 @@ work.</li>
         self._hide_link_if_necessary()
         #  event.Skip()
 
-    def _open_cell_editor_with_content_assist(self):
+    def _open_cell_editor(self):
         if not self.IsCellEditControlEnabled():
             self.EnableCellEditControl()
         row = self.GetGridCursorRow()
         celleditor = self.GetCellEditor(self.GetGridCursorCol(), row)
         celleditor.Show(True)
-        wx.CallAfter(celleditor.show_content_assist)
+        return celleditor
+
+    def _open_cell_editor_with_content_assist(self):
+        wx.CallAfter(self._open_cell_editor().show_content_assist)
 
     def _open_cell_editor_and_execute_variable_creator(
             self, list_variable=False, dict_variable=False):
-        if not self.IsCellEditControlEnabled():
-            self.EnableCellEditControl()
-        row = self.GetGridCursorRow()
-        celleditor = self.GetCellEditor(self.GetGridCursorCol(), row)
-        celleditor.Show(True)
-        wx.CallAfter(celleditor.execute_variable_creator, list_variable,
-                     dict_variable)
+        wx.CallAfter(self._open_cell_editor().execute_variable_creator,
+                     list_variable, dict_variable)
 
     def OnMakeVariable(self, event):
         self._open_cell_editor_and_execute_variable_creator(

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -573,9 +573,6 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
             elif keycode in [wx.WXK_RETURN, wx.WXK_BACK]:
                 self.save()
                 self._move_grid_cursor(event, keycode)
-            elif keycode == wx.WXK_F2:
-                celleditor = self._open_cell_editor()
-                celleditor._tc.SetFocus()
             else:
                 event.Skip()
 
@@ -910,12 +907,9 @@ class ContentAssistCellEditor(GridCellEditor):
         self._tc.set_row(row)
         self._original_value = grid.GetCellValue(row, col)
         self._tc.SetValue(self._original_value)
+        self._tc.SetSelection(0, self._tc.GetLastPosition())
+        self._tc.SetFocus()
         self._grid = grid
-        self._tc.SetInsertionPointEnd()
-        if not IS_WINDOWS:
-            self._tc.SetFocus()  # On Win 10 this breaks cell text selection
-        # For this example, select the text   # DEBUG nov_2017
-        # self._tc.SetSelection(0, self._tc.GetLastPosition())
 
     def EndEdit(self, row, col, grid, *ignored):
         value = self._get_value()
@@ -951,14 +945,9 @@ class ContentAssistCellEditor(GridCellEditor):
         elif key == wx.WXK_BACK:
             self._tc.SetValue(self._original_value)
         else:
-            self._tc.SetValue(str(key))
+            self._tc.SetValue(chr(key))
         self._tc.SetFocus()
         self._tc.SetInsertionPointEnd()
-
-    def StartingClick(self):
-        self._tc.SetValue(self._original_value)
-        self._tc.SelectAll()
-        self._tc.SetFocus()
 
     def Clone(self):
         return ContentAssistCellEditor()


### PR DESCRIPTION
I've found a way to improve the [fix for Windows 10 selection issue](https://github.com/robotframework/RIDE/issues/1739), so that it doesn't cause focus issues when F2 key is used.

Unlike the other Operating Systems, it seems that on Windows 10 grid selection breaks if `SetFocus()` is used before `SetSelection()` or `SelectAll()`. I removed `StartingClick()` because that was the main culprit behind the out of order call.

With this fix, behavior for entering edit mode will be the same for both F2 and double click (entire cell text will be selected). I will add the other enhancements we talked about for F2 with another PR.

#2135