### PR TITLE
Fixed crash when you delete tag and more

### DIFF
--- a/src/robotide/editor/tags.py
+++ b/src/robotide/editor/tags.py
@@ -188,7 +188,7 @@ class TagBox(wx.TextCtrl):
         self._update_value()
         # Send skip event only if tagbox is empty and about to be destroyed
         # On some platforms this event is sent too late and causes crash
-        if self.value != '':
+        if self and self.value != '':
             event.Skip()
 
     def _update_value(self):
@@ -237,7 +237,7 @@ class _TagBoxProperties(object):
         return self.enabled
 
     def change_value(self, value):
-        if self.modifiable and value != self.text:
+        if self.modifiable and (value != self.text or self.text == ''):
             self._tag.controller.execute(ChangeTag(self._tag, value))
 
     def activate(self, tagbox):

--- a/src/robotide/editor/tags.py
+++ b/src/robotide/editor/tags.py
@@ -167,7 +167,11 @@ class TagBox(wx.TextCtrl):
                 self._update_value()
             elif event.GetKeyCode() == wx.WXK_DELETE:
                 self.SetValue('')
-        event.Skip()
+
+        if event.GetKeyCode() != wx.WXK_RETURN:
+            # Don't send skip event if enter key is pressed
+            # On some platforms this event is sent too late and causes crash
+            event.Skip()
 
     def _cancel_editing(self):
         self.SetValue(self._properties.text)


### PR DESCRIPTION
I also fixed 2 additional issues I found while investigating this:
- Tagbox is left empty, without being destroyed, if you empty the content of a new tag
![image](https://user-images.githubusercontent.com/39315668/75637943-31180780-5c32-11ea-9b5f-7a1901eb0e2a.png)
- the following runtime error appears if you click on another tag, instead of pressing ENTER key after you delete a tag
```
Traceback (most recent call last):
  File "C:\Python37\lib\site-packages\robotide\editor\tags.py", line 191, in OnKillFocus
    if self.value != '':
  File "C:\Python37\lib\site-packages\robotide\editor\tags.py", line 204, in value
    return self.GetValue().strip()
RuntimeError: wrapped C/C++ object of type TagBox has been deleted
```
Fixes #2146