### PR TITLE
Update treenodehandlers.py to prevent freeze ups

### DIFF
--- a/src/robotide/ui/treenodehandlers.py
+++ b/src/robotide/ui/treenodehandlers.py
@@ -88,7 +88,7 @@ class _ActionHandler(wx.Window):
     _label_open_folder =  'Open Containing Folder'
 
     def __init__(self, controller, tree, node, settings):
-        wx.Window.__init__(self, tree)
+        wx.Window.__init__(self, tree.GetParent())
         self.controller = controller
         self._tree = tree
         self._node = node


### PR DESCRIPTION
The _ActionHandler class is based off wx.Window which causes a native widget to be created. Avoid adding this native window to the tree to prevent Windows OS freezes when the tree is scrolled. Add it to the tree's parent instead.
Looks like the only wx.Window feature utilized is for popup menus when a tree item is right-clicked.
Attempts to fix #1843.