### PR TITLE
Fix for 1668: Given a large test suite, selecting all tests from the root of tree, freezes RIDE for some time

### DIFF
--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -381,7 +381,7 @@ class TestRunnerPlugin(Plugin):
         return ret == wx.YES
 
     def _tests_selected(self):
-        return len(self._names_to_run) != 0
+        return len(self._selected_tests) != 0
 
     def ask_user_to_run_anyway(self):
         ret = wx.MessageBox('No tests selected. \n'

--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -137,7 +137,11 @@ class TestRunnerPlugin(Plugin):
         self._test_runner = TestRunner(application.model)
         self._register_shortcuts()
         self._min_log_level_number = LOG_LEVELS['INFO']
-        self._names_to_run = set()
+        self._selected_tests: {TestCaseController} = set()
+
+    @property
+    def _names_to_run(self):
+        return list(map(lambda ctrl: (ctrl.datafile_controller.longname, ctrl.longname), self._selected_tests))
 
     def _register_shortcuts(self):
         self.register_shortcut('CtrlCmd-C', self._copy_from_out)
@@ -220,7 +224,7 @@ class TestRunnerPlugin(Plugin):
             self.save_setting(setting, data.new)
 
     def OnTestSelectedForRunningChanged(self, message):
-        self._names_to_run = message.tests
+        self._selected_tests = message.tests
 
     def disable(self):
         self._remove_from_notebook()
@@ -306,7 +310,7 @@ class TestRunnerPlugin(Plugin):
         if not self._can_start_running_tests():
             return
         if self.__getattr__('confirm run'):
-            if not self.tests_selected():
+            if not self._tests_selected():
                 if not self.ask_user_to_run_anyway():
                     # In Linux NO runs dialog 4 times
                     return
@@ -376,7 +380,7 @@ class TestRunnerPlugin(Plugin):
                             wx.ICON_QUESTION | wx.YES_NO)
         return ret == wx.YES
 
-    def tests_selected(self):
+    def _tests_selected(self):
         return len(self._names_to_run) != 0
 
     def ask_user_to_run_anyway(self):

--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -60,6 +60,7 @@ from robotide.action.shortcut import localize_shortcuts
 from robotide.context import IS_WINDOWS, IS_MAC
 from robotide.contrib.testrunner import TestRunner
 from robotide.contrib.testrunner import runprofiles
+from robotide.controller.macrocontrollers import TestCaseController
 from robotide.publish import RideSettingsChanged, PUBLISHER
 from robotide.publish.messages import RideTestSelectedForRunningChanged
 from robotide.pluginapi import Plugin, ActionInfo

--- a/src/robotide/controller/filecontrollers.py
+++ b/src/robotide/controller/filecontrollers.py
@@ -626,6 +626,13 @@ class TestDataDirectoryController(_DataController, _FileSystemElement, _BaseCont
         self.parent.children[index] = result
         return result
 
+    def retrieve_test_controllers(self):
+        controllers: list[TestCaseController] = []
+        for child in self.children:
+            if isinstance(child,TestCaseFileController) or isinstance(child,TestDataDirectoryController):
+                controllers += child.retrieve_test_controllers()
+        return controllers
+
 
 class DirtyRobotDataException(Exception):
     """
@@ -705,6 +712,11 @@ class TestCaseFileController(_FileSystemElement, _DataController):
     def get_template(self):
         return self.data.setting_table.test_template
 
+    def retrieve_test_controllers(self) :
+        controllers = []
+        for test_ctrl in iter(self.tests):
+            controllers.append(test_ctrl)
+        return controllers
 
 class ResourceFileControllerFactory(object):
 

--- a/src/robotide/controller/macrocontrollers.py
+++ b/src/robotide/controller/macrocontrollers.py
@@ -312,6 +312,7 @@ class TestCaseController(_WithStepsController):
 
     def _init(self, test):
         self._test = test
+        self._run_passed = None
 
     def __eq__(self, other):
         if self is other:
@@ -389,6 +390,18 @@ class TestCaseController(_WithStepsController):
             return template
         return self.datafile_controller.get_template()
 
+    @property
+    def run_passed(self):
+        return self._run_passed
+
+    @run_passed.setter
+    def run_passed(self,value):
+        if value == True:
+            self._run_passed = True # Test execution passed
+        elif value == False:
+            self._run_passed = False # Test execution failed
+        else:
+            self._run_passed = None # Test did not run
 
 class UserKeywordController(_WithStepsController):
     _populator = robotapi.UserKeywordPopulator

--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -210,7 +210,7 @@ class TestSelectionController(object):
         RideTestSelectedForRunningChanged(tests=self._tests).publish()
 
     def add_tag(self, name):
-        for test in self._tests.values():
+        for test in self._tests:
             self._add_tag_to_test(name, test)
 
     def _add_tag_to_test(self, name, test):

--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -196,12 +196,15 @@ class TestSelectionController(object):
             self.select(test, selected, notifySelection=False)
         self._send_selection_changed_message()
 
-    def select(self, test: TestCaseController, selected=True, notifySelection=True):
-        if selected:
+    def select(self, test: TestCaseController, doSelect=True, notifySelection=True):
+        changed = False
+        if doSelect and not self.is_test_selected(test):
             self._tests.add(test)
-        elif self.is_test_selected(test):
+            changed = True
+        elif not doSelect and self.is_test_selected(test):
             self._tests.remove(test)
-        if notifySelection:
+            changed = True
+        if notifySelection and changed:
             self._send_selection_changed_message()
 
     def _send_selection_changed_message(self):

--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -215,8 +215,11 @@ class TestSelectionController(object):
             self.send_selection_changed_message(test,False)
 
     def unselect_all(self, tests):
+        self.select_all(tests,selected=False)
+
+    def select_all(self, tests,selected=True):
         for test in tests:
-            self.select(test, False)
+            self.select(test, selected)
 
     def select(self, test: TestCaseController, selected=True):
         if selected:
@@ -225,9 +228,10 @@ class TestSelectionController(object):
         elif self.is_test_selected(test):
             del self._tests[test.longname]
             self._tests_for_event.remove((test.datafile_controller.longname, test.longname))
-        self.send_selection_changed_message(test,selected)
+        self.send_selection_changed_message(test, selected)
 
     def send_selection_changed_message(self, changed_test, changed_selection):
+        # Shouldn't be this a private method?
         RideTestSelectedForRunningChanged(tests=self._tests_for_event,
                                           change_test_controller=changed_test, change_selected=changed_selection).publish()
 

--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -212,28 +212,29 @@ class TestSelectionController(object):
         self._tests = {}
         self._tests_for_event = set()
         for test in prev_tests.values():
-            self.send_selection_changed_message(test,False)
+            self.send_selection_changed_message()
 
     def unselect_all(self, tests):
         self.select_all(tests,selected=False)
 
     def select_all(self, tests,selected=True):
         for test in tests:
-            self.select(test, selected)
+            self.select(test, selected,notifySelection=False)
+        self.send_selection_changed_message()
 
-    def select(self, test: TestCaseController, selected=True):
+    def select(self, test: TestCaseController, selected=True,notifySelection=True):
         if selected:
             self._tests[test.longname] = test
             self._tests_for_event.add((test.datafile_controller.longname,test.longname))
         elif self.is_test_selected(test):
             del self._tests[test.longname]
             self._tests_for_event.remove((test.datafile_controller.longname, test.longname))
-        self.send_selection_changed_message(test, selected)
+        if notifySelection:
+            self.send_selection_changed_message()
 
-    def send_selection_changed_message(self, changed_test, changed_selection):
+    def send_selection_changed_message(self):
         # Shouldn't be this a private method?
-        RideTestSelectedForRunningChanged(tests=self._tests_for_event,
-                                          change_test_controller=changed_test, change_selected=changed_selection).publish()
+        RideTestSelectedForRunningChanged(tests=self._tests_for_event).publish()
 
     def add_tag(self, name):
         for test in self._tests.values():

--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -177,6 +177,7 @@ class TestSelectionController(object):
 
     def __init__(self):
         self._tests = {}
+        self._tests_for_event = set()
         self._subscribe()
 
     def _subscribe(self):
@@ -209,6 +210,7 @@ class TestSelectionController(object):
     def clear_all(self):
         prev_tests = self._tests
         self._tests = {}
+        self._tests_for_event = set()
         for test in prev_tests.values():
             self.send_selection_changed_message(test,False)
 
@@ -219,13 +221,14 @@ class TestSelectionController(object):
     def select(self, test: TestCaseController, selected=True):
         if selected:
             self._tests[test.longname] = test
+            self._tests_for_event.add((test.datafile_controller.longname,test.longname))
         elif self.is_test_selected(test):
             del self._tests[test.longname]
+            self._tests_for_event.remove((test.datafile_controller.longname, test.longname))
         self.send_selection_changed_message(test,selected)
 
     def send_selection_changed_message(self, changed_test, changed_selection):
-        RideTestSelectedForRunningChanged(tests=set([(t.datafile_controller.longname, t.longname)
-                                                     for t in self._tests.values()]),
+        RideTestSelectedForRunningChanged(tests=self._tests_for_event,
                                           change_test_controller=changed_test, change_selected=changed_selection).publish()
 
     def add_tag(self, name):

--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -215,11 +215,11 @@ class TestSelectionController(object):
             self.send_selection_changed_message()
 
     def unselect_all(self, tests):
-        self.select_all(tests,selected=False)
+        self.select_all(tests, selected=False)
 
-    def select_all(self, tests,selected=True):
+    def select_all(self, tests, selected=True):
         for test in tests:
-            self.select(test, selected,notifySelection=False)
+            self.select(test, selected, notifySelection=False)
         self.send_selection_changed_message()
 
     def select(self, test: TestCaseController, selected=True,notifySelection=True):

--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -206,8 +206,8 @@ class TestSelectionController(object):
             self._send_selection_changed_message()
 
     def _send_selection_changed_message(self):
-        # Shouldn't be this a private method?
-        RideTestSelectedForRunningChanged(tests=self._tests).publish()
+        message = RideTestSelectedForRunningChanged(tests=self._tests)
+        wx.CallAfter(message.publish)
 
     def add_tag(self, name):
         for test in self._tests:

--- a/src/robotide/controller/ui/treecontroller.py
+++ b/src/robotide/controller/ui/treecontroller.py
@@ -185,7 +185,6 @@ class TestSelectionController(object):
         return test in self._tests
 
     def clear_all(self):
-        prev_tests = self._tests
         self._tests = set()
         self._send_selection_changed_message()
 

--- a/src/robotide/publish/messages.py
+++ b/src/robotide/publish/messages.py
@@ -192,7 +192,7 @@ class RideTestExecutionStarted(RideMessage):
 
 class RideTestSelectedForRunningChanged(RideMessage):
     """Sent whenever a test is selected or unselected from the tree."""
-    data = ['tests']
+    data = ['tests','change_test_controller', 'change_selected']
 
 
 class RideTestRunning(RideMessage):

--- a/src/robotide/publish/messages.py
+++ b/src/robotide/publish/messages.py
@@ -192,7 +192,7 @@ class RideTestExecutionStarted(RideMessage):
 
 class RideTestSelectedForRunningChanged(RideMessage):
     """Sent whenever a test is selected or unselected from the tree."""
-    data = ['tests','change_test_controller', 'change_selected']
+    data = ['tests']
 
 
 class RideTestRunning(RideMessage):

--- a/src/robotide/ui/treenodehandlers.py
+++ b/src/robotide/ui/treenodehandlers.py
@@ -526,7 +526,6 @@ class _TestOrUserKeywordHandler(_CanBeRenamed, _ActionHandler):
 class TestCaseHandler(_TestOrUserKeywordHandler):
     def __init__(self, controller, tree, node, settings):
         _TestOrUserKeywordHandler.__init__(self, controller, tree, node, settings)
-        self._test_tuple = (controller.datafile_controller.longname,controller.longname)
         PUBLISHER.subscribe(self.test_selection_changed, RideTestSelectedForRunningChanged,
                             key=self)  # TODO: unsubscribe when the object is destroyed!
 
@@ -540,7 +539,7 @@ class TestCaseHandler(_TestOrUserKeywordHandler):
         return RenameTest(new_name)
 
     def test_selection_changed(self, message: RideTestSelectedForRunningChanged):
-        if self._test_tuple in message.tests:
+        if self.controller in message.tests:
             if not self.node.GetValue():
                 self._tree.CheckItem(self.node, checked=True)
         else:

--- a/src/robotide/ui/treenodehandlers.py
+++ b/src/robotide/ui/treenodehandlers.py
@@ -526,7 +526,7 @@ class _TestOrUserKeywordHandler(_CanBeRenamed, _ActionHandler):
 class TestCaseHandler(_TestOrUserKeywordHandler):
     def __init__(self, controller, tree, node, settings):
         _TestOrUserKeywordHandler.__init__(self, controller, tree, node, settings)
-
+        self._test_tuple = (controller.datafile_controller.longname,controller.longname)
         PUBLISHER.subscribe(self.test_selection_changed, RideTestSelectedForRunningChanged,
                             key=self)  # TODO: unsubscribe when the object is destroyed!
 
@@ -540,9 +540,12 @@ class TestCaseHandler(_TestOrUserKeywordHandler):
         return RenameTest(new_name)
 
     def test_selection_changed(self, message: RideTestSelectedForRunningChanged):
-        if message.change_test_controller == self.controller and self.node.GetValue() != message.change_selected:
-            self._tree.CheckItem(self.node, checked=message.change_selected)
-
+        if self._test_tuple in message.tests:
+            if not self.node.GetValue():
+                wx.CallAfter(self._tree.CheckItem, self.node, checked=True)
+        else:
+            if self.node.GetValue():
+                wx.CallAfter(self._tree.CheckItem, self.node, checked=False)
 
 class UserKeywordHandler(_TestOrUserKeywordHandler):
     is_user_keyword = True

--- a/src/robotide/ui/treenodehandlers.py
+++ b/src/robotide/ui/treenodehandlers.py
@@ -542,10 +542,10 @@ class TestCaseHandler(_TestOrUserKeywordHandler):
     def test_selection_changed(self, message: RideTestSelectedForRunningChanged):
         if self._test_tuple in message.tests:
             if not self.node.GetValue():
-                wx.CallAfter(self._tree.CheckItem, self.node, checked=True)
+                self._tree.CheckItem(self.node, checked=True)
         else:
             if self.node.GetValue():
-                wx.CallAfter(self._tree.CheckItem, self.node, checked=False)
+                self._tree.CheckItem(self.node, checked=False)
 
 class UserKeywordHandler(_TestOrUserKeywordHandler):
     is_user_keyword = True

--- a/src/robotide/ui/treenodehandlers.py
+++ b/src/robotide/ui/treenodehandlers.py
@@ -488,7 +488,7 @@ class TestCaseFileHandler(_FileHandlerThanCanBeRenamed, TestDataHandler):
 
     @overrides(_FileHandlerThanCanBeRenamed)
     def _rename_ok_handler(self):
-        self._tree.DeselectAllTests(self._node)
+        self._tree.SelectAllTests(self._node,False)
 
 
 class _TestOrUserKeywordHandler(_CanBeRenamed, _ActionHandler):

--- a/src/robotide/ui/treeplugin.py
+++ b/src/robotide/ui/treeplugin.py
@@ -902,10 +902,7 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
         return node.GetType() == 1
 
     def DeselectTests(self, tests):
-        def foo(t):
-            if self.GetPyData(t).controller in tests:
-                self.CheckItem(t, checked=False)
-        self._for_all_tests(self._root, foo)
+        self._test_selection_controller.unselect_all(tests)
 
     def SelectFailedTests(self, item):
         def func(t):

--- a/src/robotide/ui/treeplugin.py
+++ b/src/robotide/ui/treeplugin.py
@@ -889,15 +889,19 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
         self._test_selection_controller.unselect_all(tests)
 
     def SelectFailedTests(self, item):
+        all_controllers = self.retrieveTestCaseControllers(item)
         test_controllers = filter(
             lambda ctrl: ctrl.run_passed == False,
-            self.retrieveTestCaseControllers(item))
+            all_controllers)
+        self._test_selection_controller.unselect_all(all_controllers)
         self._test_selection_controller.select_all(test_controllers)
 
     def SelectPassedTests(self, item):
+        all_controllers = self.retrieveTestCaseControllers(item)
         test_controllers = filter(
             lambda ctrl: ctrl.run_passed == True,
-            self.retrieveTestCaseControllers(item))
+            all_controllers)
+        self._test_selection_controller.unselect_all(all_controllers)
         self._test_selection_controller.select_all(test_controllers)
 
     def OnClose(self, event):
@@ -964,7 +968,14 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
         node = self._controller.find_node_by_controller(controller)
         if node:
             self.SetItemText(node, data.item.name)
-            self._test_selection_controller.send_selection_changed_message() #Whyyyyyy???
+
+            """
+            This is a porkaround: selected tests are referenced by name.
+            When a test changes its name, that must also change in the test selection
+            references.
+            """
+            self._test_selection_controller.send_selection_changed_message()
+
         if controller.dirty:
             self._controller.mark_node_dirty(
                 self._get_datafile_node(controller.datafile))

--- a/src/robotide/ui/treeplugin.py
+++ b/src/robotide/ui/treeplugin.py
@@ -904,9 +904,6 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
     def _is_test_node(self, node):
         return node.GetType() == 1
 
-    def DeselectAllTests(self, item):
-        self._for_all_tests(item, lambda t: self.CheckItem(t, checked=False))
-
     def DeselectTests(self, tests):
         def foo(t):
             if self.GetPyData(t).controller in tests:

--- a/src/robotide/ui/treeplugin.py
+++ b/src/robotide/ui/treeplugin.py
@@ -847,9 +847,7 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
         :return: Nothing
         """
         test_controllers = self.retrieveTestCaseControllers(item)
-
-        for tc in test_controllers:
-            self._test_selection_controller.select(tc,selected)
+        self._test_selection_controller.select_all(test_controllers,selected)
 
     def retrieveTestCaseControllers(self, item: GenericTreeItem):
         data = item.GetData()
@@ -907,8 +905,8 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
         self.Hide()
 
     def OnTreeItemChecked(self, event):
-        node = event.GetItem()
-        handler = self._controller.get_handler(node=node)
+        node: GenericTreeItem = event.GetItem()
+        handler: TestCaseHandler = self._controller.get_handler(node=node)
         self._test_selection_controller.select(
             handler.controller, node.IsChecked())
 
@@ -966,7 +964,7 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
         node = self._controller.find_node_by_controller(controller)
         if node:
             self.SetItemText(node, data.item.name)
-            self._test_selection_controller.send_selection_changed_message(None, None) #Whyyyyyy???
+            self._test_selection_controller.send_selection_changed_message() #Whyyyyyy???
         if controller.dirty:
             self._controller.mark_node_dirty(
                 self._get_datafile_node(controller.datafile))

--- a/src/robotide/ui/treeplugin.py
+++ b/src/robotide/ui/treeplugin.py
@@ -851,10 +851,7 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
             self._test_selection_controller.select(tc,selected)
 
     def SelectTests(self, tests):
-        def foo(t):
-            if self.GetPyData(t).controller in tests:
-                self.CheckItem(t)
-        self._for_all_tests(self._root, foo)
+            self._test_selection_controller.select_all(tests)
 
     def ExpandAllSubNodes(self, item):
         self._expand_or_collapse_nodes(item, self.Expand)

--- a/src/robotide/ui/treeplugin.py
+++ b/src/robotide/ui/treeplugin.py
@@ -969,13 +969,6 @@ class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
         if node:
             self.SetItemText(node, data.item.name)
 
-            """
-            This is a porkaround: selected tests are referenced by name.
-            When a test changes its name, that must also change in the test selection
-            references.
-            """
-            self._test_selection_controller.send_selection_changed_message()
-
         if controller.dirty:
             self._controller.mark_node_dirty(
                 self._get_datafile_node(controller.datafile))

--- a/utest/controller/ui/test_treecontroller.py
+++ b/utest/controller/ui/test_treecontroller.py
@@ -142,8 +142,9 @@ class TestTestSelectionController(unittest.TestCase):
         self.assertFalse(self._tsc.is_empty())
 
     def test_test_selection_is_empty_after_removing_same_test_from_there_even_when_it_is_not_the_same_object(self):
-        self._tsc.select(self._create_test())
-        self._tsc.select(self._create_test(), False)
+        test = self._create_test()
+        self._tsc.select(test)
+        self._tsc.select(test, False)
         self.assertTrue(self._tsc.is_empty())
 
     def test_is_test_selected(self):


### PR DESCRIPTION
 1668: Selecting and deselecting tests using the right-click commands on the root of a deeply nested test folder, freezes RIDE for several minutes.
    The problem is caused by the strategy to find the test to select/deselect: expanding and collapsing all the nodes in the Tree plugin. This causes CPU waste to expand/collapse (and maybe render) and  create the tree node handlers.
    The idea of the fix is to navigate the tests using the link between controllers, in order to avoid all the dancing of the tree nodes.

To evaluate the improvement: open a large test suite. right-click on the root of the tree and "Select all tests". Click on another node of the tree. Observe the time required for the UI to return responsive. This should be noticeable even without a precise measurement. In fact, in my environment it passed _from minutes to seconds_.

A large test suite for testing is available in this comment: https://github.com/robotframework/RIDE/issues/1668#issuecomment-640885263

Notes: this code change has no effect on the initial load time of the suite. Nor affects the other performance issues of the Tree plugin. In any case, it's a relevant improvement.