### PR TITLE
Bugs fixing on editor grid

### DIFF
--- a/src/robotide/editor/clipboard.py
+++ b/src/robotide/editor/clipboard.py
@@ -15,7 +15,7 @@
 
 import os
 import wx
-from robotide.context import IS_WINDOWS
+from robotide.context import IS_WINDOWS, IS_MAC
 
 
 class _ClipboardHandler(object):
@@ -100,13 +100,20 @@ class _WindowsClipboardHandler(_ClipboardHandler):
         if self._edit_control_shown():
             self._get_edit_control().Cut()
         else:
-            _ClipboardHandler.copy(self)
+            _ClipboardHandler.cut(self)
 
     def _paste_to_cell_editor(self):
         self._get_edit_control().Paste()
 
+    def paste(self):
+        if self._edit_control_shown():
+            self._paste_to_cell_editor()
+        else:
+            _ClipboardHandler.paste(self)
 
-ClipboardHandler = IS_WINDOWS and _WindowsClipboardHandler or _ClipboardHandler
+
+# for now mac clipboard handler is the same with windows
+ClipboardHandler = _WindowsClipboardHandler if IS_WINDOWS or IS_MAC else _ClipboardHandler
 
 
 class _GridClipboard(object):

--- a/src/robotide/publish/messages.py
+++ b/src/robotide/publish/messages.py
@@ -237,6 +237,11 @@ class RideSaving(RideMessage):
     data = ['path', 'datafile']
 
 
+class RideBeforeSaving(RideMessage):
+    """Sent before files are going to be saved."""
+    pass
+
+
 class RideSaved(RideMessage):
     """Sent after the file has been actually saved to disk."""
     data = ['path']

--- a/src/robotide/ui/actiontriggers.py
+++ b/src/robotide/ui/actiontriggers.py
@@ -131,8 +131,8 @@ class _Menu(object):
         return '%s' % get_name(action.name)
 
     def _create_menu_item(self, action):
-        name_with_accerelator = self._get_name(action, build_new=True)
-        menu_item = MenuItem(self._frame, self, name_with_accerelator)
+        name_with_accelerator = self._get_name(action, build_new=True)
+        menu_item = MenuItem(self._frame, self, name_with_accelerator)
         pos = action.get_insertion_index(self.wx_menu)
         wx_menu_item = self.wx_menu.Insert(pos, menu_item.id,
                                            menu_item.name, action.doc)
@@ -282,15 +282,15 @@ class ShortcutRegistry(object):
                                                  action.shortcut))
             delegator.add(action)
             action.register(self)
-            self._update_accerelator_table()
+            self._update_accelerator_table()
 
     def unregister(self, action):
         key = action.get_shortcut()
         if self._actions[key].remove(action):
             del(self._actions[key])
-        self._update_accerelator_table()
+        self._update_accelerator_table()
 
-    def _update_accerelator_table(self):
+    def _update_accelerator_table(self):
         accelerators = []
         for delegator in self._actions.values():
             try:

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -22,7 +22,7 @@ from robotide.action import ActionInfoCollection, ActionFactory, SeparatorInfo
 from robotide.context import ABOUT_RIDE, SHORTCUT_KEYS
 from robotide.controller.ctrlcommands import SaveFile, SaveAll
 from robotide.publish import RideSaveAll, RideClosing, RideSaved, PUBLISHER,\
-    RideInputValidationError, RideTreeSelection, RideModificationPrevented
+    RideInputValidationError, RideTreeSelection, RideModificationPrevented, RideBeforeSaving
 from robotide.ui.tagdialogs import ViewAllTagsDialog
 from robotide.ui.filedialogs import RobotFilePathDialog
 from robotide.utils import RideEventHandler
@@ -475,9 +475,11 @@ class RideFrame(with_metaclass(classmaker(), wx.Frame, RideEventHandler)):
                 self.open_suite(path)
 
     def OnSave(self, event):
+        RideBeforeSaving().publish()
         self.save()
 
     def OnSaveAll(self, event):
+        RideBeforeSaving().publish()
         self.save_all()
 
     def save_all(self):


### PR DESCRIPTION
1. On Mac OS, copy/paste/cut not working in grid cell edit mode
2. Cannot save modifications in grid cell edit mode via shortcut ctrl/cmd + s
3. Deleting all text in grid cell edit mode not working
4. On Windows, performing menu action "cut" in grid cell edit mode will raise exception
5. Typos in actiontriggers.py