### PR TITLE
Redesign RideEventHandler and file system monitoring feature

### DIFF
--- a/src/robotide/application/application.py
+++ b/src/robotide/application/application.py
@@ -41,8 +41,8 @@ from .. import utils
 class RIDE(wx.App):
 
     def __init__(self, path=None, updatecheck=True):
-        self._initial_path = path
         self._updatecheck = updatecheck
+        self.workspace_path = path
         context.APP = self
         wx.App.__init__(self, redirect=False)
 
@@ -111,10 +111,10 @@ class RIDE(wx.App):
                 return maybe_editor
 
     def _load_data(self):
-        path = self._initial_path or self._get_latest_path()
-        if path:
+        self.workspace_path = self.workspace_path or self._get_latest_path()
+        if self.workspace_path:
             observer = LoadProgressObserver(self.frame)
-            self._controller.load_data(path, observer)
+            self._controller.load_data(self.workspace_path, observer)
 
     def _find_robot_installation(self):
         output = utils.run_python_command(
@@ -178,3 +178,6 @@ class RIDE(wx.App):
         wx.EventLoop.SetActive(loop)
         yield
         del loop
+
+    def OnEventLoopEnter(self, loop):
+        utils.RideFSWatcherHandler.create_fs_watcher()

--- a/src/robotide/application/application.py
+++ b/src/robotide/application/application.py
@@ -187,7 +187,8 @@ class RIDE(wx.App):
     def OnAppActivate(self, event):
         if RideFSWatcherHandler.is_watcher_created():
             if event.GetActive():
-                if RideFSWatcherHandler.is_workspace_dirty():
+                if self._controller.is_project_changed_from_disk() or \
+                        RideFSWatcherHandler.is_workspace_dirty():
                     self.frame.show_confirm_reload_dlg(event)
                 RideFSWatcherHandler.stop_listening()
             else:

--- a/src/robotide/application/application.py
+++ b/src/robotide/application/application.py
@@ -181,7 +181,8 @@ class RIDE(wx.App):
         del loop
 
     def OnEventLoopEnter(self, loop):
-        RideFSWatcherHandler.create_fs_watcher()
+        if loop and wx.EventLoopBase.IsMain(loop):
+            RideFSWatcherHandler.create_fs_watcher(self.workspace_path)
 
     def OnAppActivate(self, event):
         if RideFSWatcherHandler.is_watcher_created():

--- a/src/robotide/controller/project.py
+++ b/src/robotide/controller/project.py
@@ -23,7 +23,7 @@ from robotide.publish.messages import RideOpenSuite, RideNewProject, RideFileNam
 
 from .basecontroller import WithNamespace, _BaseController
 from .dataloader import DataLoader
-from .filecontrollers import DataController, ResourceFileControllerFactory
+from .filecontrollers import DataController, ResourceFileControllerFactory, TestDataDirectoryController
 from .robotdata import NewTestCaseFile, NewTestDataDirectory
 from robotide.spec.librarydatabase import DATABASE_FILE
 from robotide.spec.librarymanager import LibraryManager
@@ -297,9 +297,12 @@ class Project(_BaseController, WithNamespace):
 
     def is_project_changed_from_disk(self):
         for data_file in self.datafiles:
-            if data_file.has_been_modified_on_disk() or \
-                    data_file.has_been_removed_from_disk():
-                return True
+            if isinstance(data_file, TestDataDirectoryController):
+                return os.path.exists(data_file.directory)
+            else:
+                if data_file.has_been_modified_on_disk() or \
+                        data_file.has_been_removed_from_disk():
+                    return True
         return False
 
 

--- a/src/robotide/controller/project.py
+++ b/src/robotide/controller/project.py
@@ -295,6 +295,13 @@ class Project(_BaseController, WithNamespace):
         if resource:
             return self._create_resource_controller(resource)
 
+    def is_project_changed_from_disk(self):
+        for data_file in self.datafiles:
+            if data_file.has_been_modified_on_disk() or \
+                    data_file.has_been_removed_from_disk():
+                return True
+        return False
+
 
 class Serializer(object):
 

--- a/src/robotide/controller/project.py
+++ b/src/robotide/controller/project.py
@@ -298,7 +298,7 @@ class Project(_BaseController, WithNamespace):
     def is_project_changed_from_disk(self):
         for data_file in self.datafiles:
             if isinstance(data_file, TestDataDirectoryController):
-                return os.path.exists(data_file.directory)
+                return not os.path.exists(data_file.directory)
             else:
                 if data_file.has_been_modified_on_disk() or \
                         data_file.has_been_removed_from_disk():

--- a/src/robotide/controller/project.py
+++ b/src/robotide/controller/project.py
@@ -298,7 +298,8 @@ class Project(_BaseController, WithNamespace):
     def is_project_changed_from_disk(self):
         for data_file in self.datafiles:
             if isinstance(data_file, TestDataDirectoryController):
-                return not os.path.exists(data_file.directory)
+                if not os.path.exists(data_file.directory):
+                    return True
             else:
                 if data_file.has_been_modified_on_disk() or \
                         data_file.has_been_removed_from_disk():

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -30,8 +30,8 @@ from robotide.publish import (RideItemStepsChanged, RideSaved,
                               RideSettingsChanged, PUBLISHER, RideBeforeSaving)
 from robotide.usages.UsageRunner import Usages, VariableUsages
 from robotide.ui.progress import RenameProgressObserver
-from robotide import robotapi, utils
-from robotide.utils import RideEventHandler, variablematcher
+from robotide import robotapi
+from robotide.utils import variablematcher
 from robotide.widgets import Dialog, PopupMenu, PopupMenuItems
 
 from .gridbase import GridEditor
@@ -40,10 +40,7 @@ from .editordialogs import UserKeywordNameDialog, ScalarVariableDialog, \
     ListVariableDialog
 from .contentassist import ExpandingContentAssistTextCtrl
 from .gridcolorizer import Colorizer
-from robotide.lib.robot.utils.compat import with_metaclass
 
-# Metaclass fix from http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/
-from robotide.utils.noconflict import classmaker
 
 _DEFAULT_FONT_SIZE = 11
 
@@ -62,7 +59,7 @@ def requires_focus(function):
     return decorated_function
 
 
-class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
+class KeywordEditor(GridEditor):
     _no_cell = (-1, -1)
     _popup_menu_shown = False
     dirty = property(lambda self: self._controller.dirty)

--- a/src/robotide/editor/listeditor.py
+++ b/src/robotide/editor/listeditor.py
@@ -14,14 +14,10 @@
 #  limitations under the License.
 
 import wx
-from robotide.lib.robot.utils.compat import with_metaclass
 from wx.lib.mixins.listctrl import ListCtrlAutoWidthMixin
 from robotide.controller.ctrlcommands import MoveUp, MoveDown, DeleteItem
-from robotide.utils import RideEventHandler
 from robotide.widgets import PopupMenu, PopupMenuItems, ButtonWithHandler, Font
 from robotide.context import ctrl_or_cmd, bind_keys_to_evt_menu, IS_WINDOWS
-# Metaclass fix from http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/
-from robotide.utils.noconflict import classmaker
 
 
 class ListEditorBase(wx.Panel):
@@ -143,7 +139,7 @@ class ListEditorBase(wx.Panel):
         return False
 
 
-class ListEditor(with_metaclass(classmaker(), ListEditorBase, RideEventHandler)):
+class ListEditor(ListEditorBase):
     pass
 
 

--- a/src/robotide/editor/settingeditors.py
+++ b/src/robotide/editor/settingeditors.py
@@ -27,7 +27,6 @@ from robotide.widgets import ButtonWithHandler, Label, HtmlWindow, PopupMenu,\
 from robotide.publish import PUBLISHER
 from robotide import utils
 from robotide.utils.highlightmatcher import highlight_matcher
-from robotide.lib.robot.utils.compat import with_metaclass
 from .formatters import ListToStringFormatter
 from .gridcolorizer import ColorizationSettings
 from .editordialogs import EditorDialog, DocumentationDialog, MetadataDialog,\
@@ -37,11 +36,8 @@ from .listeditor import ListEditor
 from .popupwindow import HtmlPopupWindow
 from .tags import TagsDisplay
 
-# Metaclass fix from http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/
-from robotide.utils.noconflict import classmaker
 
-
-class SettingEditor(with_metaclass(classmaker(), wx.Panel, utils.RideEventHandler)):
+class SettingEditor(wx.Panel):
 
     def __init__(self, parent, controller, plugin, tree):
         wx.Panel.__init__(self, parent)

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -602,9 +602,9 @@ class RideFrame(wx.Frame):
                             style=wx.YES_NO | wx.ICON_WARNING)
         confirmed = ret == wx.YES
         if confirmed:
-            # workspace_path should update after open dictionary/suite
+            # workspace_path should update after open directory/suite
             # There're two scenarios:
-            # 1. path is a dictionary
+            # 1. path is a directory
             # 2. path is a suite file
             new_path = RideFSWatcherHandler.get_workspace_new_path()
             if new_path and os.path.exists(new_path):

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -608,12 +608,12 @@ class RideFrame(wx.Frame):
             # 2. path is a suite file
             new_path = RideFSWatcherHandler.get_workspace_new_path()
             if new_path and os.path.exists(new_path):
-                wx.CallLater(100, self.open_suite, new_path)
+                wx.CallAfter(self.open_suite, new_path)
             else:
                 # in case workspace is totally removed
                 # ask user to open new directory
                 # TODO add some notification msg to users
-                self.OnOpenDirectory(event)
+                wx.CallAfter(self.OnOpenDirectory, event)
         else:
             for _ in self._controller.datafiles:
                 if _.has_been_modified_on_disk() or _.has_been_removed_from_disk():

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -596,7 +596,7 @@ class RideFrame(wx.Frame):
         msg = ['Workspace modifications detected on the file system.',
                'Do you want to reload the workspace?',
                'Answering <No> will overwrite the changes on disk.']
-        if self.get_selected_datafile_controller().dirty:
+        if self._controller.is_dirty():
             msg.insert(2, 'Answering <Yes> will discard unsaved changes.')
         ret = wx.MessageBox('\n'.join(msg), 'Files Changed On Disk',
                             style=wx.YES_NO | wx.ICON_WARNING)

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -178,7 +178,6 @@ class RideFrame(wx.Frame):
         self.Bind(wx.EVT_MAXIMIZE, self.OnMaximize)
         self.Bind(wx.EVT_DIRCTRL_FILEACTIVATED, self.OnOpenFile)
         self.Bind(wx.EVT_TREE_ITEM_RIGHT_CLICK, self.OnMenuOpenFile)
-        self.Bind(wx.EVT_ACTIVATE, self.OnActivate)
         self._subscribe_messages()
         wx.CallAfter(self.actions.register_tools)  # DEBUG
 
@@ -593,17 +592,7 @@ class RideFrame(wx.Frame):
         ctrl = SizeReportCtrl(self, -1, wx.DefaultPosition, wx.Size(width, height), self._mgr)
         return ctrl
 
-    def OnActivate(self, event):
-        if RideFSWatcherHandler.is_watcher_created():
-            if event.GetActive():
-                if RideFSWatcherHandler.is_workspace_dirty():
-                    self._show_confirm_reload_popup(event)
-                RideFSWatcherHandler.stop_listening()
-            else:
-                RideFSWatcherHandler.start_listening(self._application.workspace_path)
-        event.Skip()
-
-    def _show_confirm_reload_popup(self, event):
+    def show_confirm_reload_dlg(self, event):
         msg = ['Workspace modifications detected on the file system.',
                'Do you want to reload the workspace?',
                'Answering <No> will overwrite the changes on disk.']

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -617,6 +617,9 @@ class RideFrame(wx.Frame):
         else:
             for _ in self._controller.datafiles:
                 if _.has_been_modified_on_disk() or _.has_been_removed_from_disk():
+                    if not os.path.exists(_.directory):
+                        # sub folder is removed, create new one before saving
+                        os.makedirs(_.directory)
                     _.mark_dirty()
             self.save_all()
 

--- a/src/robotide/ui/treeplugin.py
+++ b/src/robotide/ui/treeplugin.py
@@ -25,11 +25,9 @@ from ..controller.macrocontrollers import TestCaseController
 
 TREETEXTCOLOUR = Colour(0xA9, 0xA9, 0xA9)
 
-from robotide.lib.robot.utils.compat import with_metaclass
 from robotide.controller.ui.treecontroller import TreeController, \
     TestSelectionController
 from robotide.context import IS_WINDOWS
-from robotide.action.actioninfo import ActionInfo
 from robotide.controller.filecontrollers import ResourceFileController, TestDataDirectoryController, \
     TestCaseFileController
 from robotide.publish.messages import RideTestRunning, RideTestPaused, \
@@ -51,8 +49,7 @@ from robotide.widgets import PopupCreator
 from robotide import utils
 from .treenodehandlers import ResourceRootHandler, action_handler_class, ResourceFileHandler
 from .images import TreeImageList
-# Metaclass fix from http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/
-from robotide.utils.noconflict import classmaker
+
 
 _TREE_ARGS = {'style': wx.TR_DEFAULT_STYLE}
 _TREE_ARGS['agwStyle'] = customtreectrl.TR_DEFAULT_STYLE | customtreectrl.TR_HIDE_ROOT | \
@@ -160,9 +157,7 @@ class TreePlugin(Plugin):
         self._tree._refresh_view()
 
 
-class Tree(with_metaclass(classmaker(), treemixin.DragAndDrop,
-                          customtreectrl.CustomTreeCtrl,
-                          utils.RideEventHandler)):
+class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl):
     _RESOURCES_NODE_LABEL = 'External Resources'
 
     def __init__(self, parent, action_registerer, settings=None):

--- a/src/robotide/utils/__init__.py
+++ b/src/robotide/utils/__init__.py
@@ -25,7 +25,7 @@ from robotide.lib.robot.utils import printable_name, normalize, eq, ET, \
     unic, asserts, unescape, html_escape, attribute_escape, robottime,\
     get_timestamp, Matcher, is_list_like, is_dict_like, system_decode,\
     ArgumentParser, get_error_details, is_unicode, is_string, py2to3
-from .eventhandler import RideEventHandler
+from .eventhandler import RideEventHandler, RideFSWatcherHandler
 from .printing import Printing
 
 

--- a/src/robotide/utils/__init__.py
+++ b/src/robotide/utils/__init__.py
@@ -25,7 +25,7 @@ from robotide.lib.robot.utils import printable_name, normalize, eq, ET, \
     unic, asserts, unescape, html_escape, attribute_escape, robottime,\
     get_timestamp, Matcher, is_list_like, is_dict_like, system_decode,\
     ArgumentParser, get_error_details, is_unicode, is_string, py2to3
-from .eventhandler import RideEventHandler, RideFSWatcherHandler
+from .eventhandler import RideFSWatcherHandler
 from .printing import Printing
 
 

--- a/src/robotide/utils/eventhandler.py
+++ b/src/robotide/utils/eventhandler.py
@@ -39,11 +39,11 @@ class RideEventHandler(with_metaclass(eventhandlertype, object)):
     _SHOWING_REMOVED_ON_DISK_CONTROLLERS_ = set()
 
     def _can_be_edited(self, event):
-        ctrl = self.get_selected_datafile_controller()
-        if ctrl and ctrl.has_been_removed_from_disk():
-            return self._show_removed_from_disk_warning(ctrl, event)
-        if ctrl and ctrl.has_been_modified_on_disk():
-            return self._show_modified_on_disk_warning(ctrl, event)
+        # ctrl = self.get_selected_datafile_controller()
+        # if ctrl and ctrl.has_been_removed_from_disk():
+        #     return self._show_removed_from_disk_warning(ctrl, event)
+        # if ctrl and ctrl.has_been_modified_on_disk():
+        #     return self._show_modified_on_disk_warning(ctrl, event)
         return True
 
     def _show_removed_from_disk_warning(self, ctrl, event):
@@ -90,3 +90,37 @@ class RideEventHandler(with_metaclass(eventhandlertype, object)):
 
     def get_selected_datafile_controller(self):
         raise NotImplementedError(self.__class__.__name__)
+
+
+class _RideFSWatcherHandler:
+
+    def __init__(self):
+        self._fs_watcher = None
+        self._is_workspace_dirty = False
+
+    def create_fs_watcher(self):
+        if self._fs_watcher:
+            return
+        self._fs_watcher = wx.FileSystemWatcher()
+        self._fs_watcher.Bind(wx.EVT_FSWATCHER, self._on_fs_event)
+
+    def start_listening(self, path):
+        self.stop_listening()
+        self._fs_watcher.AddTree(path)
+
+    def stop_listening(self):
+        self._is_workspace_dirty = False
+        self._fs_watcher.RemoveAll()
+
+    def is_workspace_dirty(self):
+        return self._is_workspace_dirty
+
+    def is_watcher_created(self):
+        return self._fs_watcher is not None
+
+    def _on_fs_event(self, event):
+        # skip access / attribute event
+        self._is_workspace_dirty = True
+
+
+RideFSWatcherHandler = _RideFSWatcherHandler()

--- a/src/robotide/utils/eventhandler.py
+++ b/src/robotide/utils/eventhandler.py
@@ -68,8 +68,7 @@ class _RideFSWatcherHandler:
         previous_path = event.GetPath()
         change_type = event.GetChangeType()
 
-        if change_type in (wx.FSW_EVENT_CREATE,
-                           wx.FSW_EVENT_MODIFY):
+        if change_type == wx.FSW_EVENT_CREATE:
             if os.path.isdir(previous_path):
                 return True
             elif os.path.isfile(previous_path):

--- a/src/robotide/utils/eventhandler.py
+++ b/src/robotide/utils/eventhandler.py
@@ -15,7 +15,7 @@
 
 import wx
 import os
-
+from robotide.context import IS_WINDOWS
 
 class _RideFSWatcherHandler:
 
@@ -49,6 +49,11 @@ class _RideFSWatcherHandler:
         self._fs_watcher.RemoveAll()
 
     def is_workspace_dirty(self):
+        if self._is_workspace_dirty and IS_WINDOWS:
+            # for windows, rename workspace cannot be detected
+            # use this workaround if watched path not exists
+            if not os.path.exists(self._watched_path):
+                self._is_workspace_dirty = False
         return self._is_workspace_dirty
 
     def is_watcher_created(self):

--- a/src/robotide/utils/eventhandler.py
+++ b/src/robotide/utils/eventhandler.py
@@ -17,6 +17,7 @@ import wx
 import os
 from robotide.context import IS_WINDOWS
 
+
 class _RideFSWatcherHandler:
 
     _TYPE_ATTRIBUTE = 32
@@ -49,11 +50,11 @@ class _RideFSWatcherHandler:
         self._fs_watcher.RemoveAll()
 
     def is_workspace_dirty(self):
-        if self._is_workspace_dirty and IS_WINDOWS:
-            # for windows, rename workspace cannot be detected
+        if not self._is_workspace_dirty and IS_WINDOWS:
+            # in windows, rename workspace root folder cannot be detected
             # use this workaround if watched path not exists
-            if not os.path.exists(self._watched_path):
-                self._is_workspace_dirty = False
+            if self._watched_path and not os.path.exists(self._watched_path):
+                self._is_workspace_dirty = True
         return self._is_workspace_dirty
 
     def is_watcher_created(self):
@@ -79,7 +80,7 @@ class _RideFSWatcherHandler:
             # folder is deleted:
             self._is_workspace_dirty = True
             if previous_path == self._watched_path:
-                # current workspace folder has been removed
+                # current workspace root folder has been removed
                 self._watched_path = None
             return
 

--- a/src/robotide/utils/eventhandler.py
+++ b/src/robotide/utils/eventhandler.py
@@ -15,16 +15,9 @@
 
 import wx
 import os
-from robotide.context import IS_WINDOWS
 
 
 class _RideFSWatcherHandler:
-
-    _TYPE_ATTRIBUTE = 32
-    _TYPE_CREATE = 1
-    _TYPE_DELETE = 2
-    _TYPE_RENAME = 4
-    _TYPE_MODIFY = 8
 
     def __init__(self):
         self._fs_watcher = None
@@ -75,19 +68,14 @@ class _RideFSWatcherHandler:
         previous_path = event.GetPath()
         change_type = event.GetChangeType()
 
-        # TODO skip access / attribute event
-
-        if change_type == _RideFSWatcherHandler._TYPE_ATTRIBUTE:
-            return False
-
-        elif change_type in (_RideFSWatcherHandler._TYPE_CREATE,
-                             _RideFSWatcherHandler._TYPE_MODIFY):
+        if change_type in (wx.FSW_EVENT_CREATE,
+                           wx.FSW_EVENT_MODIFY):
             if os.path.isdir(previous_path):
                 return True
             elif os.path.isfile(previous_path):
                 return self._is_valid_file_format(previous_path)
 
-        elif change_type == _RideFSWatcherHandler._TYPE_DELETE:
+        elif change_type == wx.FSW_EVENT_DELETE:
             if previous_path == self._watched_path:
                 # workspace root folder / suite file is deleted
                 self._watched_path = None
@@ -98,7 +86,7 @@ class _RideFSWatcherHandler:
             else:
                 return self._is_valid_file_format(previous_path)
 
-        elif change_type == _RideFSWatcherHandler._TYPE_RENAME:
+        elif change_type == wx.FSW_EVENT_RENAME:
             if previous_path == self._watched_path:
                 # workspace root folder / suite file is renamed
                 self._watched_path = new_path

--- a/src/robotide/utils/eventhandler.py
+++ b/src/robotide/utils/eventhandler.py
@@ -36,10 +36,10 @@ class _RideFSWatcherHandler:
         if not os.path.exists(path):
             return
         if os.path.isdir(path):
+            # only watch folders
+            # MSW do not support watch single file
             path = os.path.join(path, '')
             self._fs_watcher.AddTree(path)
-        else:
-            self._fs_watcher.Add(path)
         self._watched_path = path
 
     def stop_listening(self):


### PR DESCRIPTION
- Directory workspace
In the following scenario will trigger reload workspace confirm dialog, when confirmed, it will reload whole workspace, otherwise, it will discard changes
1. create/modify/delete/rename files from outer editor, only works for .robot,.txt,.tsv,.resource
2. create/rename/delete sub folders
3. rename/delete workspace root folder, note: in the case, when confirmed reload, will ask user to open new directory

- Single suite file workspace
if this file is renamed/deleted, will also trigger reload workspace confirm dialog, when confirmed reload, will ask user to open new directory

Tested in windows, macOS and Ubuntu with wxPython 4.1.0.

**Looks like wx.FileSystemWatcher cannot work properly in MacOS with wxPython 4.0.7.post2**