### PR TITLE
Fix cannot edit grid cell with wxPython 4.1.0

### DIFF
--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -186,7 +186,6 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
         self.Bind(grid.EVT_GRID_CELL_LEFT_DCLICK, self.OnCellLeftDClick)
         self.Bind(grid.EVT_GRID_LABEL_RIGHT_CLICK, self.OnLabelRightClick)
         self.Bind(grid.EVT_GRID_LABEL_LEFT_CLICK, self.OnLabelLeftClick)
-        self.Bind(wx.EVT_KILL_FOCUS, self.OnKillFocus)
 
     def get_tooltip_content(self):
         _iscelleditcontrolshown = self.IsCellEditControlShown()
@@ -214,12 +213,6 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
         self._cell_selected = True
         GridEditor.OnSelectCell(self, event)
         self._colorize_grid()
-        event.Skip()
-
-    def OnKillFocus(self, event):
-        self._tooltips.hide()
-        self._hide_link_if_necessary()
-        self.save()
         event.Skip()
 
     def _execute(self, command):

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -186,6 +186,7 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
         self.Bind(grid.EVT_GRID_CELL_LEFT_DCLICK, self.OnCellLeftDClick)
         self.Bind(grid.EVT_GRID_LABEL_RIGHT_CLICK, self.OnLabelRightClick)
         self.Bind(grid.EVT_GRID_LABEL_LEFT_CLICK, self.OnLabelLeftClick)
+        self.Bind(wx.EVT_KILL_FOCUS, self.OnKillFocus)
 
     def get_tooltip_content(self):
         _iscelleditcontrolshown = self.IsCellEditControlShown()
@@ -213,6 +214,11 @@ class KeywordEditor(with_metaclass(classmaker(), GridEditor, RideEventHandler)):
         self._cell_selected = True
         GridEditor.OnSelectCell(self, event)
         self._colorize_grid()
+        event.Skip()
+
+    def OnKillFocus(self, event):
+        self._tooltips.hide()
+        self._hide_link_if_necessary()
         event.Skip()
 
     def _execute(self, command):


### PR DESCRIPTION
With wxPython 4.1.0, cannot edit grid cells in windows and linux, to resolve it, I removed the useless event listener OnKillFocus.

Verified with both wxPython 4.0.7.post2 and wxPython 4.1.0