### PR TITLE
Fix win10 system freeze when loading large project

### DIFF
--- a/src/robotide/ui/treenodehandlers.py
+++ b/src/robotide/ui/treenodehandlers.py
@@ -55,7 +55,7 @@ def action_handler_class(controller):
     }[controller.__class__]
 
 
-class _ActionHandler(wx.Window):
+class _ActionHandler:
     is_user_keyword = False
     is_test_suite = False
     is_variable = False
@@ -88,13 +88,11 @@ class _ActionHandler(wx.Window):
     _label_open_folder =  'Open Containing Folder'
 
     def __init__(self, controller, tree, node, settings):
-        wx.Window.__init__(self, tree)
         self.controller = controller
         self._tree = tree
         self._node = node
         self._settings = settings
         self._rendered = False
-        self.Show(False)
         self._popup_creator = tree._popup_creator
 
     @property
@@ -106,7 +104,7 @@ class _ActionHandler(wx.Window):
         return self._node
 
     def show_popup(self):
-        self._popup_creator.show(self, PopupMenuItems(self, self._actions),
+        self._popup_creator.show(self._tree, PopupMenuItems(self, self._actions),
                                  self.controller)
 
     def begin_label_edit(self):
@@ -559,7 +557,7 @@ class UserKeywordHandler(_TestOrUserKeywordHandler):
     def _create_rename_command(self, new_name):
         return RenameKeywordOccurrences(
             self.controller.name, new_name,
-            RenameProgressObserver(self.GetParent().GetParent()),
+            RenameProgressObserver(self._tree.GetParent()),
             self.controller.info)
 
     def OnFindUsages(self, event):
@@ -603,7 +601,7 @@ class ResourceRootHandler(_ActionHandler):
 
     def OnAddResource(self, event):
         path = RobotFilePathDialog(
-            self, self.controller, self._settings).execute()
+            self._tree, self.controller, self._settings).execute()
         if path:
             self.controller.load_resource(path, LoadProgressObserver(self))
 

--- a/src/robotide/widgets/popupmenu.py
+++ b/src/robotide/widgets/popupmenu.py
@@ -54,14 +54,14 @@ class PopupMenu(wx.Menu):
             if item.is_separator():
                 self.AppendSeparator()
             else:
-                self._add_item(parent, item)
+                self._add_item(item)
         parent.PopupMenu(self)
         self.Destroy()
 
-    def _add_item(self, parent, item):
+    def _add_item(self, item):
         id_ = wx.NewIdRef()
         self.Append(id_, item.name)
-        parent.Bind(wx.EVT_MENU, item.callable, id=id_)
+        self.Bind(wx.EVT_MENU, item.callable, id=id_)
 
 
 class PopupMenuItems(object):


### PR DESCRIPTION
class _ActionHandler's inheritance "wx.Window" is not necessary at all.

Remove this inheritance will fix this issue, and in the same time, it will improve the tree plugin's performance significantly