### PR TITLE
Fix frame size is incorrect when maximize app window

### DIFF
--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -140,7 +140,7 @@ class RideFrame(wx.Frame):
 
     def __init__(self, application, controller):
         size = application.settings.get('mainframe size', (1100, 700))
-        wx.Frame.__init__(self, parent=None, id = wx.ID_ANY, title='RIDE',
+        wx.Frame.__init__(self, parent=None, id=wx.ID_ANY, title='RIDE',
                           pos=application.settings.get('mainframe position', (50, 30)),
                           size=size, style=wx.DEFAULT_FRAME_STYLE | wx.SUNKEN_BORDER)
 
@@ -341,8 +341,13 @@ class RideFrame(wx.Frame):
             wx.CloseEvent.Veto(event)
 
     def OnSize(self, event):
-        self._application.settings['mainframe maximized'] = self.IsMaximized()
-        self._application.settings['mainframe size'] = self.DoGetSize()
+        size = self.DoGetSize()
+        is_full_screen_mode = size == wx.DisplaySize()
+        self._application.settings['mainframe maximized'] = self.IsMaximized() or is_full_screen_mode
+        if not is_full_screen_mode:
+            self._application.settings['mainframe size'] = size
+        self._application.settings['mainframe position'] = \
+            self.DoGetPosition()
         event.Skip()
 
     def OnMove(self, event):


### PR DESCRIPTION
This issue is not fully fixed.

Here're the test cases for this PR:

Case 1. delete config file -> launch RIDE -> double click app title, app maximize -> restart app (Only fixed this case in last PR)
Case 2. open app -> click maxmize button -> restart app (**bug fixed on MacOS**)
Case 3. open app -> click maxmize button -> restart app -> double click app title (**bug fixed on MacOS**)
Case 4. open app -> resize window -> restart app (**bug fixed on MacOS**)
Case 5. open app -> resize window -> move window position -> restart app
Case 6. open app -> resize window -> move window position -> minimize window -> restart app
Case 7. open app -> double click app title, app maximize -> minimize window -> restart app

Check app position and size are correct and no corners are hidden.

I tested in windows, Mac OS and linux.