### PR TITLE
Make publisher errors slient

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,7 +45,7 @@ and this project adheres to http://semver.org/spec/v2.0.0.html[Semantic Versioni
 
 === Fixed
 
-- Fixed incorrect tittle in manage plugin settings
+- Fixed incorrect title in manage plugin settings
 - Fixed search in Text Editor with wxPython 4.1.0
 - Fixed resource file will disappear after saving from Text Editor
 - Fixed duplicated resource file/folder in tree nodes

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,6 +45,7 @@ and this project adheres to http://semver.org/spec/v2.0.0.html[Semantic Versioni
 
 === Fixed
 
+- Fixed incorrect tittle in manage plugin settings
 - Fixed search in Text Editor with wxPython 4.1.0
 - Fixed resource file will disappear after saving from Text Editor
 - Fixed duplicated resource file/folder in tree nodes

--- a/src/robotide/context/coreplugins.py
+++ b/src/robotide/context/coreplugins.py
@@ -28,5 +28,5 @@ def get_core_plugins():
     from robotide.spec.specimporter import SpecImporterPlugin
     from robotide.postinstall.desktopshortcut import ShortcutPlugin
 
-    return [RunAnything, RecentFilesPlugin, PreviewPlugin, SpecImporterPlugin, EditorPlugin, TextEditorPlugin,
-            KeywordSearch, LogPlugin, TestSearchPlugin, ShortcutPlugin, ParserLogPlugin, TreePlugin, FileExplorerPlugin]
+    return [LogPlugin, RunAnything, RecentFilesPlugin, PreviewPlugin, SpecImporterPlugin, EditorPlugin, TextEditorPlugin,
+            KeywordSearch, TestSearchPlugin, ShortcutPlugin, ParserLogPlugin, TreePlugin, FileExplorerPlugin]

--- a/src/robotide/editor/texteditor.py
+++ b/src/robotide/editor/texteditor.py
@@ -338,10 +338,10 @@ class SourceEditor(wx.Panel):
         self._title = title
         self._tab_size = self._parent._app.settings.get(
                       'txt number of spaces', 4)
+        self._position = None
         self._create_ui(title)
         self._data = None
         self._dirty = 0  # 0 is False and 1 is True, when changed on this editor
-        self._position = None
         self._showing_list = False
         self._tab_open = None
         # self._autocomplete = None

--- a/src/robotide/editor/texteditor.py
+++ b/src/robotide/editor/texteditor.py
@@ -338,10 +338,10 @@ class SourceEditor(wx.Panel):
         self._title = title
         self._tab_size = self._parent._app.settings.get(
                       'txt number of spaces', 4)
-        self._position = None
         self._create_ui(title)
         self._data = None
         self._dirty = 0  # 0 is False and 1 is True, when changed on this editor
+        self._position = None
         self._showing_list = False
         self._tab_open = None
         # self._autocomplete = None

--- a/src/robotide/log/log.py
+++ b/src/robotide/log/log.py
@@ -87,7 +87,7 @@ class LogPlugin(Plugin):
         if self._panel:
             self._panel.update_log()
         if self.log_to_console:
-            print("".format(_message_to_string(message)))  # >> sys.stdout, _message_to_string(message)
+            print('{}'.format(_message_to_string(message)))
         if self.log_to_file:
             self._logfile.write(_message_to_string(message))
             self._outfile.flush()

--- a/src/robotide/publish/messages.py
+++ b/src/robotide/publish/messages.py
@@ -125,7 +125,7 @@ class RideLogException(RideLog):
             message += '\n\nTraceback (most recent call last):\n%s\n%s' % \
                 (str(exception), ''.join(traceback.format_list(tb)))
         RideMessage.__init__(
-            self, message=message, level=level, notify_user=False,
+            self, message=message, level=level, notify_user=notify_user,
             timestamp=utils.get_timestamp(), exception=exception)
 
 

--- a/src/robotide/publish/publisher.py
+++ b/src/robotide/publish/publisher.py
@@ -78,11 +78,9 @@ class ListenerExceptionHandler(pub.IListenerExcHandler):
 
     def __call__(self, listenerID: str, topicObj: pub.Topic):
         from .messages import RideLogException
-        from robotide.context import LOG
         topic_name = topicObj.getName()
         if topic_name != RideLogException.topic():
             error_msg = 'Error in listener: {}, topic: {}'.format(listenerID, topic_name)
-            LOG.error(error_msg)
             RideLogException(message=error_msg,
                              exception=None, level='ERROR').publish()
 

--- a/src/robotide/publish/publisher.py
+++ b/src/robotide/publish/publisher.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
 import inspect
 from pubsub import pub
 from typing import Type, Callable
@@ -81,8 +82,10 @@ class ListenerExceptionHandler(pub.IListenerExcHandler):
         topic_name = topicObj.getName()
         if topic_name != RideLogException.topic():
             error_msg = 'Error in listener: {}, topic: {}'.format(listenerID, topic_name)
-            RideLogException(message=error_msg,
-                             exception=None, level='ERROR').publish()
+            log_message = RideLogException(message=error_msg,
+                                           exception=None, level='ERROR')
+            sys.stderr.write(log_message.__getattribute__('message'))
+            log_message.publish()
 
 
 """Global `Publisher` instance for subscribing to and unsubscribing from RideMessages."""

--- a/src/robotide/ui/pluginmanager.py
+++ b/src/robotide/ui/pluginmanager.py
@@ -53,8 +53,7 @@ class _PluginPanel(wx.Panel):
         self.SetSizer(sizer)
 
     def _create_header(self):
-        header_panel = wx.Panel(self, wx.ID_ANY)
-        header = Label(header_panel, wx.ID_ANY, "Installed Plugins")
+        header = Label(self, wx.ID_ANY, "Installed Plugins\n")
         header.SetFont(wx.Font(wx.FontInfo(14).Family(wx.FONTFAMILY_SWISS).Bold()))
         return header
 

--- a/utest/plugin/test_messages.py
+++ b/utest/plugin/test_messages.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 
 import unittest
+from unittest.mock import patch
 from nose.tools import assert_equal, assert_true, assert_raises
 from robotide.publish import RideMessage, RideLog
 from robotide.pluginapi import Plugin
@@ -133,7 +134,8 @@ class TestBrokenMessageListener(unittest.TestCase):
     def tearDown(self):
         self.plugin.disable()
 
-    def test_broken_listener(self):
+    @patch('sys.stderr.write')
+    def test_broken_listener(self, p_stderr):
         self.plugin.subscribe(self.plugin.error_listener, RideLog)
         RideTestMessage().publish()
         assert_true(self.plugin.error.message.startswith(
@@ -141,6 +143,7 @@ class TestBrokenMessageListener(unittest.TestCase):
             'Wrong error message text: ' + self.plugin.error.message)
         assert_equal(self.plugin.error.topic(), 'ride.log.exception')
         assert_equal(self.plugin.error.level, 'ERROR')
+        p_stderr.assert_called_once()
 
     def test_broken_error_listener_does_not_cause_infinite_recusrion(self):
         self.plugin.subscribe(self.plugin.broken_listener, RideLog)

--- a/utest/publish/test_message_publishing.py
+++ b/utest/publish/test_message_publishing.py
@@ -240,7 +240,7 @@ class TestPublisher(unittest.TestCase):
         PUBLISHER.publish(RideTestMessageWithAttrs, 'test')
         assert_equal(len(TestPublisher.cls_msgs), 4 * 2)
 
-    @patch('robotide.context.LOG.error')
+    @patch('sys.stderr.write')
     def test_subscribe_broken_listener(self, p_log):
         PUBLISHER.subscribe(self._broken_listener, RideTestMessageWithAttrs)
         msg_obj = RideTestMessageWithAttrs(foo='one', bar='two')
@@ -248,7 +248,7 @@ class TestPublisher(unittest.TestCase):
         assert_equal(self._msg, msg_obj)
         p_log.assert_called_once()
 
-    @patch('robotide.context.LOG.error')
+    @patch('sys.stderr.write')
     def test_subscribe_broken_listener_ride_log(self, p_log):
         PUBLISHER.subscribe(self._broken_listener, RideTestMessageWithAttrs)
         PUBLISHER.subscribe(self._listener, RideLogException)
@@ -258,7 +258,7 @@ class TestPublisher(unittest.TestCase):
         assert_true(isinstance(self._msg, RideLogException))
         assert_equal(len(TestPublisher.cls_msgs), 2)
 
-    @patch('robotide.context.LOG.error')
+    @patch('sys.stderr.write')
     def test_subscribe_broken_listener_ride_log_broken(self, p_log):
         PUBLISHER.subscribe(self._broken_listener, RideTestMessageWithAttrs)
         PUBLISHER.subscribe(self._broken_listener, RideLogException)

--- a/utest/resources/fake.cfg
+++ b/utest/resources/fake.cfg
@@ -1,0 +1,2 @@
+auto imports = []
+pythonpath = []

--- a/utest/resources/mocks.py
+++ b/utest/resources/mocks.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
 from robotide.preferences.settings import Settings
 from robotide.preferences.excludes import Excludes
 from robotide.publish import PUBLISHER
@@ -69,7 +70,7 @@ class _FakeUIObject(object):
 
 class FakeSettings(Settings):
     def __init__(self, settings=None):
-        Settings.__init__(self, None)
+        Settings.__init__(self, os.path.join(os.path.dirname(__file__), 'fake.cfg'))
         self.add_section('Plugins')
         self.set('pythonpath', [])
         self.set('auto imports', [])

--- a/utest/ui/test_tree.py
+++ b/utest/ui/test_tree.py
@@ -173,12 +173,14 @@ class TestAddingItems(_BaseSuiteTreeTest):
 
     def test_adding_user_keyword(self):
         suite = self._model.data
+        self._tree.select_node_by_data(suite)
         kw = suite.create_keyword('New Fake UK')
         self._tree.add_keyword(self._get_node(suite.name), kw)
         assert_equal(self._get_selected_label(), 'New Fake UK')
 
     def test_adding_test(self):
         suite = self._model.data.children[0]
+        self._tree.select_node_by_data(suite)
         create_test = suite.create_test('New Fake Test')
         self._tree.add_test(self._get_node(suite.name), create_test)
         assert_equal(self._get_selected_label(), 'New Fake Test')


### PR DESCRIPTION
- LogPlugin should be loaded in the first, because some error message could be printed in log plugin during other plugin loading
- Title in plugin manage setting page cannot show properly