### PR TITLE
Fixed RIDE cannot close properly when Screenshot library is loaded

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,6 +45,7 @@ and this project adheres to http://semver.org/spec/v2.0.0.html[Semantic Versioni
 
 === Fixed
 
+- Fixed RIDE cannot close properly when Screenshot library is loaded
 - Fixed incorrect title in manage plugin settings
 - Fixed search in Text Editor with wxPython 4.1.0
 - Fixed resource file will disappear after saving from Text Editor

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -337,6 +337,11 @@ class RideFrame(wx.Frame):
             self._mgr.UnInit()
             self._task_bar_icon.Destroy()
             self.Destroy()
+            app = wx.GetApp()
+            if app is not self._application:
+                # other wx app instance created unexpectedly
+                # this will cause RIDE app instance cannot invoke ExitMainLoop properly
+                self._application.ExitMainLoop()
         else:
             wx.CloseEvent.Veto(event)
 


### PR DESCRIPTION
Fixed RIDE cannot close properly when Screenshot library is loaded