### PR TITLE
Fix sys stderr is none in pythonw

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,6 +45,7 @@ and this project adheres to http://semver.org/spec/v2.0.0.html[Semantic Versioni
 
 === Fixed
 
+- Fixed sys.stderr is None errors if RIDE is launched by pythonw.exe
 - Fixed RIDE cannot close properly when Screenshot library is loaded
 - Fixed incorrect title in manage plugin settings
 - Fixed search in Text Editor with wxPython 4.1.0

--- a/src/robotide/__init__.py
+++ b/src/robotide/__init__.py
@@ -53,6 +53,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'lib'))
 
 
 def main(*args):
+    _replace_std_for_win()
     noupdatecheck, debug_console, inpath = _parse_args(args)
     if len(args) > 3 or '--help' in args:
         print(__doc__)
@@ -99,6 +100,26 @@ def _run(inpath=None, updatecheck=True, debug_console=False):
         wx.lib.inspection.InspectionTool().Show()
         debugconsole.start(ride)
     ride.MainLoop()
+
+
+def _replace_std_for_win():
+
+    class NullStream:
+        def close(self): pass
+
+        def flush(self): pass
+
+        def write(self, line): pass
+
+        def writelines(self, sequence): pass
+
+    if sys.executable.endswith('pythonw.exe'):
+        # In windows, when launching RIDE with pythonw.exe
+        # sys.stderr and sys.stdout will be None
+        if sys.stderr is None:
+            sys.stderr = NullStream()
+        if sys.stdout is None:
+            sys.stdout = NullStream()
 
 
 def _show_old_wxpython_warning_if_needed(parent=None):


### PR DESCRIPTION
When launching RIDE with pythonw.exe, the `sys.stdout` & `sys.stderr` will be None, and some errors may occur.

Related issue: 
https://github.com/robotframework/RIDE/issues/2319
https://github.com/robotframework/RIDE/issues/2197