### PR TITLE
Minor fixes

### DIFF
--- a/src/robotide/controller/project.py
+++ b/src/robotide/controller/project.py
@@ -118,7 +118,6 @@ class Project(_BaseController, WithNamespace):
 
     def new_resource(self, path, parent=None):
         res = self._namespace.new_resource(path)
-        self.update_default_dir(path)
         resource_controller = self._create_resource_controller(res, parent)
         return resource_controller
 

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -124,7 +124,7 @@ class KeywordEditor(GridEditor):
 
     @requires_focus
     def _resize_grid(self):
-        if self.settings.get("auto size cols", True):
+        if self.settings.get("auto size cols", False):
             self.AutoSizeColumns(False)
         if self.settings.get("word wrap", True):
             self.AutoSizeRows(False)


### PR DESCRIPTION
1. When user have old RIDE version with config files, this will cause "auto size cols" is activated automatically.
2. Create new resource should not change the project default dir path, this will cause ${EXEC_DIR} cannot be resolved correctly.