### PR TITLE
Include kwonlyargs support

### DIFF
--- a/src/robotide/spec/libraryfetcher.py
+++ b/src/robotide/spec/libraryfetcher.py
@@ -32,14 +32,12 @@ def get_import_result(path, args):
 
 def _parse_args(args):
     parsed = []
-    if args.positional:
-        parsed.extend(list(args.positional))
-    if args.defaults:
-        for i, value in enumerate(args.defaults):
-            index = len(args.positional) - len(args.defaults) + i
-            parsed[index] = parsed[index] + '=' + str(args.defaults[value])  # DEBUG str(value)
+    for name in args.positional:
+        parsed.append('='.join([name, str(args.defaults[name])]) if name in args.defaults else name)
     if args.varargs:
         parsed.append('*%s' % args.varargs)
+    for name in args.kwonlyargs:
+        parsed.append('='.join([name, str(args.defaults[name])]) if name in args.defaults else name)
     if args.kwargs:
         parsed.append('**%s' % args.kwargs)
     return parsed

--- a/utest/resources/robotdata/libs/TestLib.py
+++ b/utest/resources/robotdata/libs/TestLib.py
@@ -10,3 +10,6 @@ def testlib_keyword_with_args(arg1, arg2='default value', *args):
     This is some more documentation
     """
     pass
+
+def testlib_keyword_with_kwonlyargs(arg1, *args, namedarg1, namedarg2='default value', **kwargs):
+    pass

--- a/utest/spec/test_iteminfo.py
+++ b/utest/spec/test_iteminfo.py
@@ -53,6 +53,14 @@ class TestKeywordInfo(unittest.TestCase):
         assert_in_details(kw_info, 'TestLib',
                           '[ arg1 | arg2=default value | *args ]')
 
+    def test_libkw_kwonly_arguments_parsing(self):
+        libname = 'TestLib'
+        lib = TestLibrary(libname)
+        kw = lib.handlers['testlib_keyword_with_kwonlyargs']
+        kw_info = LibraryKeywordInfo(kw.name, kw.doc, lib.doc_format, kw.library.name, libraryfetcher._parse_args(kw.arguments))
+        assert_in_details(kw_info, 'TestLib',
+                          '[ arg1 | *args | namedarg1 | namedarg2=default value | **kwargs ]')
+
     def test_uk_arguments_parsing(self):
         uk = UserKeyword(_FakeTestCaseFile(), 'My User keyword')
         uk.args.value = ['${arg1}', '${arg2}=def', '@{varargs}']


### PR DESCRIPTION
Fix the issue (#2342) where python keyword libraries fail to load in RIDE due to named arguments. e.g.:
def kw(self, *, arg1=None):