### PR TITLE
Fix #2433

### DIFF
--- a/src/robotide/lib/robot/parsing/populators.py
+++ b/src/robotide/lib/robot/parsing/populators.py
@@ -101,6 +101,7 @@ class FromFilePopulator(object):
         return bool(self._datafile)
 
     def add(self, row):
+        print(f"DEBUG: populators enter row={row}")
         if PROCESS_CURDIR and self._curdir:
             row = self._replace_curdirs_in(row)
         data = DataRow(row, self._datafile.source)

--- a/src/robotide/lib/robot/parsing/robotreader.py
+++ b/src/robotide/lib/robot/parsing/robotreader.py
@@ -16,7 +16,7 @@
 import re
 
 from robotide.lib.robot.output import LOGGER
-from robotide.lib.robot.utils import JYTHON, Utf8Reader, prepr
+from robotide.lib.robot.utils import Utf8Reader, prepr
 
 NBSP = u'\xa0'
 
@@ -31,12 +31,9 @@ class RobotReader(object):
 
     def read(self, file, populator, path=None):
         path = path or getattr(file, 'name', '<file-like object>')
-        # print(f"DEBUG: RobotReader enter read file ({type(file)}) populator {populator} path {path}")
         process = False
         for lineno, line in enumerate(Utf8Reader(file).readlines(), start=1):
-            print(f"DEBUG: reader before row({lineno}) split: line={line}")
             cells = self.split_row(line.rstrip())
-            print(f"DEBUG: reader after row split: cells={cells}\n")
             cells = list(self._check_deprecations(cells, path, lineno))
             if cells and cells[0].strip().startswith('*') and \
                     populator.start_table([c.replace('*', '').strip()
@@ -70,28 +67,24 @@ class RobotReader(object):
                 else:
                     start_s_quote = True
             if line[i] == '#' and not start_d_quote and not start_s_quote:
-                index = i
-                break
-            else:
-                i += 1
+                try:
+                    if line[i-1] != '\\' and line[i+1] == ' ':
+                        index = i
+                        break
+                except IndexError:
+                    i += 1
+                    continue
+            i += 1
         if index < len(line):
-            # print(f"DEBUG: reader sharp_strip line {len(line)} index={index} split={line[:(index-1)]}")
             cells = self._space_splitter.split(line[:(index-1)])
-            # print(f"DEBUG: reader sharp_strip cells={cells}")
             row.extend(cells)
             row.append(line[index:])
-            # print(f"DEBUG: reader sharp_strip final")
         else:
-            #print(f"DEBUG: reader sharp_strip normal split {line}")
-            #test=re.split(r"([ \t\xa0]{2}|\t+)", line)
-            #print(f"DEBUG: reader sharp_strip local re split {test}")
             row = self._space_splitter.split(line)
-            # print(f"DEBUG: reader sharp_strip local split {row}")
         # Remove empty cells after first non-empty
         first_non_empty = -1
         if row:
             for i, v in enumerate(row):
-                # print(f"DEBUG: reader sharp_strip row[i]={v}")
                 if v != '':
                     first_non_empty = i
                     break
@@ -99,7 +92,6 @@ class RobotReader(object):
                 for i in range(len(row)-1, first_non_empty, -1):
                     if row[i] == '':
                         row.pop(i)
-        # print(f"DEBUG: reader sharp_strip returning row={row}")
         return row
 
     def split_row(self, row):
@@ -107,12 +99,7 @@ class RobotReader(object):
             row = row[1:-1] if row[-2:] in self._pipe_ends else row[1:]
             return [self._strip_whitespace(cell)
                     for cell in self._pipe_splitter.split(row)]
-        lrow = self.sharp_strip(row)
-        #if lrow:
-        #    return lrow[1:]
-        return lrow
-        # print(f"DEBUG: reader split_row before space_splitter: row={row}")
-        # return cls._space_splitter.split(row)
+        return self.sharp_strip(row)
 
     def _check_deprecations(self, cells, path, line_number):
         for original in cells:
@@ -131,7 +118,8 @@ class RobotReader(object):
     def _strip_whitespace(cls, string):
         return string.strip()
 
-    def _normalize_whitespace(self, string):
+    @staticmethod
+    def _normalize_whitespace(string):
         if string.startswith('#'):
             return string
         return ' '.join(string.split())

--- a/src/robotide/lib/robot/parsing/tablepopulators.py
+++ b/src/robotide/lib/robot/parsing/tablepopulators.py
@@ -148,7 +148,8 @@ class ForLoopPopulator(Populator):
         self._declaration_comments = []
 
     def add(self, row):
-        dedented_row = row.dedent()
+        dedented_row = row.dedent()  # DEBUG remove dedent
+        # print(f"DEBUG: Forloop Add row = {row.data}")
         if not self._loop:
             declaration_ready = self._populate_declaration(row)
             if not declaration_ready:
@@ -157,11 +158,13 @@ class ForLoopPopulator(Populator):
         if not row.is_continuing():
             self._populator.populate()
             self._populator = StepPopulator(self._loop.add_step)
-        self._populator.add(dedented_row)
+        self._populator.add(dedented_row)  #DEBUG remove dedent
+        #self._populator.add(row)
 
     def _populate_declaration(self, row):
         if row.starts_for_loop() or row.is_continuing():
-            self._declaration.extend(row.dedent().data)
+            self._declaration.extend(row.dedent().data)  #DEBUG remove dedent
+            # self._declaration.extend(row.data)
             self._declaration_comments.extend(row.comments)
             return False
         return True

--- a/utest/controller/test_for_loop.py
+++ b/utest/controller/test_for_loop.py
@@ -198,7 +198,37 @@ class TestForLoop(unittest.TestCase):
     def test_move_for_loop_header_between_for_loops(self):
         test = self.project.datafiles[1].tests[18]
         test.execute(MoveRowsDown([3]))
-        self.assertEqual(test.steps[4].as_list()[1], '${j}')
+        self.assertEqual(test.steps[4].as_list()[2], '${j}')
+
+    def test_move_for_loop_in_mulitlevels(self):
+        loop_1 = ['', 'FOR', '${loop1}', 'IN RANGE', '1', '19']
+        inside_NO = ['', '', '', 'No Operation']
+        loop_2 = ['', '', '', 'FOR', '${loop2}', 'IN RANGE', '${loop1}', '20']
+        inside_NO_2 = ['', '', '', '', '', 'No Operation']
+        loop_3 = ['', '', '', '', '', 'FOR', '${loop3}', 'IN RANGE', '2', '4']
+        inside_NO_3 = ['', '', '', '', '', '', '', 'No Operation']
+        inside_L3 = ['', '', '', '', '', '', '', 'Log', 'This is loop 3: ${loop3}']
+        inside_E3 = ['', '', '', '', '', 'END']
+        inside_L2 = ['', '', '', '', '', 'Log', 'This is loop 2: ${loop2}']
+        inside_E2 = ['', '', '', 'END']
+        inside_L1 = ['', '', '', 'Log', 'This is loop 1: ${loop1}']
+        inside_LG = ['', '', '', 'Log', 'Generic']
+        inside_E1 = ['', 'END']
+        test = self.project.datafiles[1].tests[19]
+        print("DEBUG: Test 19:")
+        for s in test.steps:
+            print(f"{s.as_list()}")
+        self._verify_steps(test.steps, loop_1, inside_NO, loop_2, inside_NO_2, loop_3, inside_NO_3, inside_L3,
+                           inside_NO_3, inside_E3, inside_NO_2, inside_L2, inside_E2, inside_L1, inside_NO,
+                           inside_LG, inside_E1)
+        """
+        test.execute(MoveRowsUp([2]))
+        self._verify_steps(test.steps, loop_1, loop_2, inside_1, inside_2)
+        test.execute(MoveRowsUp([1]))
+        self._verify_steps(test.steps, loop_2, loop_1, inside_1, inside_2)
+        test.execute(MoveRowsDown([0]))
+        self._verify_steps(test.steps, loop_1, loop_2, inside_1, inside_2)
+        """
 
     def _verify_steps(self, steps, *expected):
         for step, exp in zip(steps, expected):

--- a/utest/resources/robotdata/forloop/forloop.robot
+++ b/utest/resources/robotdata/forloop/forloop.robot
@@ -97,3 +97,21 @@ Test 18
     FOR  ${k}  IN  1  2  3  4
     \   No Operation
     \   No Operation
+
+Test 19
+    FOR    ${loop1}    IN RANGE    1    19
+        No Operation
+        FOR    ${loop2}    IN RANGE    ${loop1}    20
+            No Operation
+            FOR    ${loop3}    IN RANGE    2    4
+                No Operation
+                Log    This is loop 3: ${loop3}
+                No Operation
+            END
+            No Operation
+            Log    This is loop 2: ${loop2}
+        END
+        Log    This is loop 1: ${loop1}
+        No Operation
+        Log    Generic
+    END


### PR DESCRIPTION
With this fix only # followed by a space are split into cells.
Rules for not splitting cells by #:

- " # inside "
- ' # inside '
- \\# escaped
- \# not followed by a space, for example like in: css:input#btn_search  color=#6dbfc0 

Closes #2433 