### PR TITLE
Fix for diacritic characters display on RIDE console

### DIFF
--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -602,7 +602,6 @@ class TestRunnerPlugin(Plugin):
 
     def _append_to_console_log(self, text, source="stdout"):
         """Put output to the text control"""
-        
         self._append_text(self._console_log_ctrl, text, source)
         if self._console_log:
             FileWriter.write(self._console_log, [text], "ab", "a")

--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -603,25 +603,6 @@ class TestRunnerPlugin(Plugin):
     def _append_to_console_log(self, text, source="stdout"):
         """Put output to the text control"""
         
-        # Is there need for decoding (on windows platform this is often the case!)?
-        # Note: if characters are not correctly displayed when running TC on command line they will end up as ? on RIDE console
-        if isinstance(text, (bytes, bytearray)):
-            textlen = len(text)
-            if textlen > 0 and platform == 'win32' and source == 'stdout':
-                try:
-                    import locale
-                    prefencode = locale.getpreferredencoding()
-                    import sys
-                    defencode = sys.getdefaultencoding()
-                    if prefencode != defencode:
-                        #debugtext = 'Debug: start append to console ' + str(textlen) + str(platform) + str(prefencode) + str(defencode) + '<<<<<'
-                        #self._append_text(self._console_log_ctrl, debugtext, source)
-                        #self._append_text(self._message_log_ctrl, 'Debug: console text before decode:' + str(text), source)
-                        text = text.decode(encoding=prefencode, errors='namereplace')
-                        #self._append_text(self._message_log_ctrl, 'Debug: console text after  decode:' + str(text), source)
-                except Exception as e:
-                    text = 'Append to console log decode error: ' + str(e) + ' '
-
         self._append_text(self._console_log_ctrl, text, source)
         if self._console_log:
             FileWriter.write(self._console_log, [text], "ab", "a")

--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -36,7 +36,7 @@ Some icons courtesy Mark James and provided under a creative commons
 license.  See http://www.famfamfam.com/lab/icons/silk
 
 Note: this plugin creates a temporary directory for use while a test
-is running. This directory is normally removed when RIDE exists. If
+is running. This directory is normally removed when RIDE exits. If
 RIDE is shut down abnormally this directory may not get removed. The
 directories that are created match the pattern RIDE*.d and are in a
 temporary directory appropriate for the platform (for example, on
@@ -602,6 +602,26 @@ class TestRunnerPlugin(Plugin):
 
     def _append_to_console_log(self, text, source="stdout"):
         """Put output to the text control"""
+        
+        # Is there need for decoding (on windows platform this is often the case!)?
+        # Note: if characters are not correctly displayed when running TC on command line they will end up as ? on RIDE console
+        if isinstance(text, (bytes, bytearray)):
+            textlen = len(text)
+            if textlen > 0 and platform == 'win32' and source == 'stdout':
+                try:
+                    import locale
+                    prefencode = locale.getpreferredencoding()
+                    import sys
+                    defencode = sys.getdefaultencoding()
+                    if prefencode != defencode:
+                        #debugtext = 'Debug: start append to console ' + str(textlen) + str(platform) + str(prefencode) + str(defencode) + '<<<<<'
+                        #self._append_text(self._console_log_ctrl, debugtext, source)
+                        #self._append_text(self._message_log_ctrl, 'Debug: console text before decode:' + str(text), source)
+                        text = text.decode(encoding=prefencode, errors='namereplace')
+                        #self._append_text(self._message_log_ctrl, 'Debug: console text after  decode:' + str(text), source)
+                except Exception as e:
+                    text = 'Append to console log decode error: ' + str(e) + ' '
+
         self._append_text(self._console_log_ctrl, text, source)
         if self._console_log:
             FileWriter.write(self._console_log, [text], "ab", "a")


### PR DESCRIPTION
This is only for windows platform and when encoding settings are different (often the case in Western Europe)