### PR TITLE
Grid updates for #2512

### DIFF
--- a/src/robotide/context/__init__.py
+++ b/src/robotide/context/__init__.py
@@ -152,8 +152,8 @@ SHORTCUT_KEYS = '''\
         <td>Stop running test suite</td>
     </tr>
 </table>
-<h3>Grid</h3>
 
+<h3>Grid</h3>
 <table>
     <tr align="left">
         <th><b>Shortcut</b></th>
@@ -172,20 +172,8 @@ SHORTCUT_KEYS = '''\
         <td>Pop-up JSON Editor</td>
     </tr>
     <tr>
-        <td>CtrlCmd-I</td>
-        <td>Insert row(s)</td>
-    </tr>
-    <tr>
-        <td>CtrlCmd-D</td>
-        <td>Remove row(s)</td>
-    </tr>
-    <tr>
-        <td>Shift-CtrlCmd-I</td>
-        <td>Insert cell(s)</td>
-    </tr>
-    <tr>
-        <td>Shift-CtrlCmd-D</td>
-        <td>Remove cell(s)</td>
+        <td>CtrlCmd-B</td>
+        <td>Go to Definition</td>
     </tr>
     <tr>
         <td>CtrlCmd-Z</td>
@@ -204,20 +192,28 @@ SHORTCUT_KEYS = '''\
         <td>Make list variable body</td>
     </tr>
     <tr>
+        <td>CtrlCmd-5</td>
+        <td>Make dictionary variable body</td>
+    </tr>
+    <tr>
         <td>CtrlCmd-Shift-3</td>
         <td>Comment content with #</td>
     </tr>
     <tr>
+        <td>CtrlCmd-Shift-4</td>
+        <td>Uncomment content from #</td>
+    </tr>
+    <tr>
+        <td>Alt-Enter</td>
+        <td>Move cursor down</td>
+    </tr>
+    <tr>
+        <td>CtrlCmd-3</td>
+        <td>Comment row(s)</td>
+    </tr>
+    <tr>
         <td>CtrlCmd-4</td>
         <td>Uncomment row(s)</td>
-    </tr>
-    <tr>
-        <td>CtrlCmd-Shift-4</td>
-        <td>Uncomment content with #</td>
-    </tr>
-    <tr>
-        <td>CtrlCmd-5</td>
-        <td>Make dictionary variable body</td>
     </tr>
     <tr>
         <td>Alt-Up</td>
@@ -228,8 +224,24 @@ SHORTCUT_KEYS = '''\
         <td>Move row(s) down</td>
     </tr>
     <tr>
-        <td>Alt-Enter</td>
-        <td>Move cursor down</td>
+        <td>CtrlCmd-T</td>
+        <td>Swap row up</td>
+    </tr>
+    <tr>
+        <td>CtrlCmd-Shift-I</td>
+        <td>Insert cell(s)</td>
+    </tr>
+    <tr>
+        <td>CtrlCmd-Shift--D</td>
+        <td>Delete cell(s)</td>
+    </tr>
+    <tr>
+        <td>CtrlCmd-I</td>
+        <td>Insert row(s)</td>
+    </tr>
+    <tr>
+        <td>CtrlCmd-D</td>
+        <td>Delete row(s)</td>
     </tr>
     <tr>
         <td>CtrlCmd-A</td>
@@ -248,11 +260,11 @@ SHORTCUT_KEYS = '''\
         <td>Paste (does not move cells or rows)</td>
     </tr>
     <tr>
-        <td>Shift-CtrlCmd-V</td>
+        <td>CtrlCmd-Shift-V</td>
         <td>Insert (adds empty rows and pastes data)</td>
     </tr>
     <tr>
-        <td>Delete</td>
+        <td>Del</td>
         <td>Remove cell content</td>
     </tr>
 </table>

--- a/src/robotide/editor/__init__.py
+++ b/src/robotide/editor/__init__.py
@@ -25,24 +25,37 @@ from ..widgets import PopupCreator
 
 _EDIT = """
 [Edit]
+---
 &Undo | Undo last modification | Ctrlcmd-Z
 &Redo | Redo modification | Ctrlcmd-Y
 ---
-Cu&t | Cut | Ctrlcmd-X
-&Copy | Copy | Ctrlcmd-C
-&Paste | Paste | Ctrlcmd-V
-&Insert | Insert | Shift-Ctrl-V
-&Delete | Delete  | Del
+Make Variable | Make variable | Ctrlcmd-1
+Make List Variable | Make list variable | Ctrlcmd-2
+Make Dict Variable | Make dict variable | Ctrlcmd-5
 ---
-Comment | Comment selected rows | Ctrlcmd-3
-CommentCells | Comment cells with # | Ctrlcmd-Shift-3
-Uncomment | Uncomment selected rows | Ctrlcmd-4
-UncommentCells | Uncomment cells with # | Ctrlcmd-Shift-4
+Comment Cells | Comment selected cells with # | Ctrlcmd-Shift-3
+Uncomment Cells | Uncomment selected cells with # | Ctrlcmd-Shift-4
+Move Cursor Down | Move cursor down | Alt-Enter
+---
+Comment Rows | Comment selected rows | Ctrlcmd-3
+Uncomment Rows | Uncomment selected rows | Ctrlcmd-4
+Move Rows Up | Move selected rows up | Alt-Up
+Move Rows Down | Move selected rows down | Alt-Down
+Swap Row Up | Swap selected row with the one above | Ctrlcmd-T
 ---
 Insert Cells | Insert Cells | Shift-Ctrl-I
 Delete Cells | Delete Cells | Shift-Ctrl-D
 Insert Rows | Insert Rows | Ctrlcmd-I
 Delete Rows | Delete Rows | Ctrlcmd-D
+---
+Select All | Select All | Ctrlcmd-A
+---
+Cu&t | Cut | Ctrlcmd-X
+&Copy | Copy | Ctrlcmd-C
+&Paste | Paste | Ctrlcmd-V
+&Insert | Insert | Shift-Ctrl-V
+---
+&Delete | Delete  | Del
 [Tools]
 Content Assistance (Ctrl-Space or Ctrl-Alt-Space) | Show possible keyword and variable completions | | | POSITION-70
 """
@@ -203,6 +216,9 @@ class _EditorTab(wx.Panel):
     def OnPaste(self, event):
         self.editor.paste()
 
+    def OnSelectAll(self, event):
+        self.editor.select_all(event)
+
     def OnInsert(self, event):
         self.editor.insert()
 
@@ -222,17 +238,38 @@ class _EditorTab(wx.Panel):
     def OnDelete(self, event):
         self.editor.delete()
 
-    def OnComment(self, event):
-        self.editor.comment()
+    def OnCommentRows(self, event):
+        self.editor.comment_rows()
 
-    def OnUncomment(self, event):
-        self.editor.uncomment()
+    def OnUncommentRows(self, event):
+        self.editor.uncomment_rows()
+
+    def OnMoveRowsUp(self, event):
+        self.editor.move_rows_up()
+
+    def OnMoveRowsDown(self, event):
+        self.editor.move_rows_down()
+
+    def OnSwapRowUp(self, event):
+        self.editor.swap_row_up()
+
+    def OnMoveCursorDown(self, event):
+        self.editor.move_cursor_down()
 
     def OnCommentCells(self, event):
         self.editor.comment_cells()
 
     def OnUncommentCells(self, event):
         self.editor.uncomment_cells()
+
+    def OnMakeVariable(self, event):
+        self.editor.make_variable()
+
+    def OnMakeListVariable(self, event):
+        self.editor.make_list_variable()
+
+    def OnMakeDictVariable(self, event):
+        self.editor.make_dict_variable()
 
     def OnContentAssistance(self, event):
         self.editor.show_content_assist()

--- a/src/robotide/editor/contentassist.py
+++ b/src/robotide/editor/contentassist.py
@@ -145,26 +145,20 @@ class _ContentAssistTextCtrlBase(object):
             close_symbol = open_symbol
         return value[:from_]+open_symbol+value[from_:to_]+close_symbol+value[to_:]
 
-    def execute_add_text(self, add_text, on_the_left, on_the_right):
+    def execute_sharp_comment(self):
+        # Todo: Will only comment the left top cell for a multi cell select block!
         from_, to_ = self.GetSelection()
-        self.SetValue(self._add_text(self.Value, add_text, on_the_left, on_the_right, from_, to_))
+        #print(f"DEBUG: value from/to: " + str(from_) + " " + str(to_))
+        #print(f"DEBUG: value selected: " + self.Value)
+        add_text = '# '
+        self.SetValue(self._add_text(self.Value, add_text, True, False, from_, to_))
         lenadd = len(add_text)
         elem = self
-        if on_the_left:
-            elem.SetInsertionPoint(from_ + lenadd)
+        elem.SetInsertionPoint(from_ + lenadd)
         if from_ != to_:
-            if on_the_left and on_the_right:
-                elem.SetInsertionPoint(to_ + lenadd)
-                elem.SetSelection(from_ + lenadd, to_ + lenadd)
-                return
-            if on_the_left:
-                elem.SetInsertionPoint(to_ + lenadd)
-                elem.SetSelection(from_ + lenadd, to_ + lenadd)
-                return
-            if on_the_right:
-                elem.SetInsertionPoint(to_)
-                elem.SetSelection(from_, to_)
-                return
+            elem.SetInsertionPoint(to_ + lenadd)
+            elem.SetSelection(from_ + lenadd, to_ + lenadd)
+            return
 
     @staticmethod
     def _add_text(value, add_text, on_the_left, on_the_right, from_, to_):
@@ -176,23 +170,19 @@ class _ContentAssistTextCtrlBase(object):
             return value[:from_]+value[from_:to_]+add_text+value[to_:]
         return value
 
-    def execute_remove_text(self, remove_text, on_the_left, on_the_right):
+    def execute_sharp_uncomment(self):
+        # Todo: Will only uncomment the left top cell for a multi cell select block!
         from_, to_ = self.GetSelection()
         lenold = len(self.Value)
-        if on_the_left:
-            self.SetValue(self._remove_text(self.Value, remove_text, True, False, from_, to_))
+        self.SetValue(self._remove_text(self.Value, '# ', True, False, from_, to_))
         lenone = len(self.Value)
-        if on_the_right:
-            self.SetValue(self._remove_text(self.Value, remove_text, False, True, from_, to_))
-        lentwo = len(self.Value)
         diffone = lenold - lenone
-        difftwo = lenone - lentwo
         elem = self
         if from_ == to_:
             elem.SetInsertionPoint(from_ - diffone)
         else:
-            elem.SetInsertionPoint(to_ - diffone - difftwo)
-            elem.SetSelection(from_ - diffone, to_ - diffone - difftwo)
+            elem.SetInsertionPoint(to_ - diffone)
+            elem.SetSelection(from_ - diffone, to_ - diffone)
 
     def _remove_text(self, value, remove_text, on_the_left, on_the_right, from_, to_):
         if on_the_left and on_the_right:

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -65,14 +65,32 @@ class KeywordEditor(GridEditor, Plugin):
     dirty = property(lambda self: self._controller.dirty)
     update_value = lambda *args: None
     _popup_items = [
-                       'Create Keyword', 'Extract Keyword', 'Extract Variable',
-                       'Rename Keyword', 'Find Where Used',
-                       'JSON Editor\tCtrl-Shift-J',
-                       '---', 'Make Variable\tCtrl-1',
+                       'Create Keyword',
+                       'Extract Keyword',
+                       'Extract Variable',
+                       'Rename Keyword',
+                       'Find Where Used',
+                       'JSON Editor\tCtrl-Shift-J', 
+                       '---',
+                       'Go to Definition\tCtrl-B',
+                       '---',
+                       'Undo\tCtrl-Z',
+                       'Redo\tCtrl-Y',
+                       '---',
+                       'Make Variable\tCtrl-1',
                        'Make List Variable\tCtrl-2',
-                       'Make Dict Variable\tCtrl-5', '---',
-                       'Go to Definition\tCtrl-B', '---',
-                       'Comment cell\tCtrl-Shift-3', 'Uncomment cell\tCtrl-Shift-4', '---',
+                       'Make Dict Variable\tCtrl-5', 
+                       '---',
+                       'Comment Cells\tCtrl-Shift-3',
+                       'Uncomment Cells\tCtrl-Shift-4',
+                       'Move Cursor Down\tAlt-Enter',
+                       '---',
+                       'Comment Rows\tCtrl-3',
+                       'Uncomment Rows\tCtrl-4',
+                       'Move Rows Up\tAlt-Up',
+                       'Move Rows Down\tAlt-Down',
+                       'Swap Row Up\tCtrl-T', 
+                       '---',
                    ] + GridEditor._popup_items
 
     def __init__(self, parent, controller, tree):
@@ -263,9 +281,18 @@ class KeywordEditor(GridEditor, Plugin):
         if selected_row not in selected_rows:
             self.SelectRow(selected_row, addToSelected=False)
             self.SetGridCursor(event.Row, 0)
-        popupitems = ['Insert Rows\tCtrl-I', 'Delete Rows\tCtrl-D',
-                      'Comment Rows\tCtrl-3', 'Uncomment Rows\tCtrl-4',
-                      'Move Rows Up\tAlt-Up', 'Move Rows Down\tAlt-Down']
+        popupitems = [
+                    'Comment Rows\tCtrl-3', 
+                    'Uncomment Rows\tCtrl-4',
+                    'Move Rows Up\tAlt-Up', 
+                    'Move Rows Down\tAlt-Down',
+                    'Swap Row Up\tCtrl-T',
+                    'Insert Rows\tCtrl-I',
+                    'Delete Rows\tCtrl-D',
+                    '---',
+                    'Comment Cells\tCtrl-Shift-3',
+                    'Uncomment Cells\tCtrl-Shift-4', 
+                    ]
         PopupMenu(self, PopupMenuItems(self, popupitems))
         event.Skip()
 
@@ -293,6 +320,13 @@ class KeywordEditor(GridEditor, Plugin):
 
     def _col_label_left_click(self, event):
         pass
+
+    def OnMoveCursorDown(self, event=None):
+        topL = self.selection.topleft
+        botR = self.selection.bottomright
+        row_s, col_s = topL
+        row_e, col_e = botR
+        self.SetGridCursor(row_s+1, col_s)
 
     def OnInsertRows(self, event):
         self._execute(AddRows(self.selection.rows()))
@@ -352,12 +386,15 @@ class KeywordEditor(GridEditor, Plugin):
         self._skip_except_on_mac(event)
 
     def OnMoveRowsUp(self, event=None):
-        self._row_move(MoveRowsUp, -1)
+        self._row_move(MoveRowsUp, -1, False)
 
     def OnMoveRowsDown(self, event=None):
-        self._row_move(MoveRowsDown, 1)
+        self._row_move(MoveRowsDown, 1, False)
 
-    def _row_move(self, command, change):
+    def OnSwapRowUp(self, event=None):
+        self._row_move(MoveRowsUp, 1, True)
+
+    def _row_move(self, command, change, swap=False):
         # Workaround for double actions, see issue #2048
         if self._counter == 1:
             if IS_MAC:
@@ -371,7 +408,10 @@ class KeywordEditor(GridEditor, Plugin):
             self._counter += 1
         rows = self.selection.rows()
         if self._execute(command(rows)):
-            wx.CallAfter(self._select_rows, [r + change for r in rows])
+            if swap:
+                wx.CallAfter(self._select_rows, [r for r in rows])
+            else:
+                wx.CallAfter(self._select_rows, [r + change for r in rows])
         self._resize_grid()
 
     def _select_rows(self, rows):
@@ -563,9 +603,9 @@ class KeywordEditor(GridEditor, Plugin):
                     self.OnDeleteCells()
                 """
                 elif keycode == ord('3'):
-                    self._open_cell_editor_and_execute_add_text(add_text='# ', on_the_left=True, on_the_right=False)
+                    self._open_cell_editor_and_execute_sharp_comment()
                 elif keycode == ord('4'):
-                    self._open_cell_editor_and_execute_remove_text(remove_text='# ', on_the_left=True, on_the_right=False)
+                    self._open_cell_editor_and_execute_sharp_uncomment()
                 """
             else:
                 if keycode == wx.WXK_SPACE:
@@ -727,21 +767,19 @@ work.</li>
     def OnMakeDictVariable(self, event):
         self._open_cell_editor_and_execute_variable_creator(dict_variable=True)
 
-    def _open_cell_editor_and_execute_add_text(
-            self, add_text='', on_the_left=False, on_the_right=False):
-        wx.CallAfter(self._open_cell_editor().execute_add_text,
-                     add_text, on_the_left, on_the_right)
+    def _open_cell_editor_and_execute_sharp_comment(self):
+        # Meant for a single cell selection!
+        wx.CallAfter(self._open_cell_editor().execute_sharp_comment)
 
-    def _open_cell_editor_and_execute_remove_text(
-            self, remove_text='', on_the_left=False, on_the_right=False):
-        wx.CallAfter(self._open_cell_editor().execute_remove_text,
-                     remove_text, on_the_left, on_the_right)
+    def _open_cell_editor_and_execute_sharp_uncomment(self):
+        # Meant for a single cell selection!
+        wx.CallAfter(self._open_cell_editor().execute_sharp_uncomment)
 
-    def OnCommentCell(self, event):
-        self._open_cell_editor_and_execute_add_text(add_text='# ', on_the_left=True, on_the_right=False)
+    def OnCommentCells(self, event):
+        self._open_cell_editor_and_execute_sharp_comment()
 
-    def OnUncommentCell(self, event):
-        self._open_cell_editor_and_execute_remove_text(remove_text='# ', on_the_left=True, on_the_right=False)
+    def OnUncommentCells(self, event):
+        self._open_cell_editor_and_execute_sharp_uncomment()
 
     def OnCellRightClick(self, event):
         self._tooltips.hide()
@@ -967,11 +1005,11 @@ class ContentAssistCellEditor(GridCellEditor):
     def execute_enclose_text(self, keycode):
         self._tc.execute_enclose_text(keycode)
 
-    def execute_add_text(self, add_text='', on_the_left=False, on_the_right=False):
-        self._tc.execute_add_text(add_text, on_the_left, on_the_right)
+    def execute_sharp_comment(self):
+        self._tc.execute_sharp_comment()
 
-    def execute_remove_text(self, remove_text='', on_the_left=False, on_the_right=False):
-        self._tc.execute_remove_text(remove_text, on_the_left, on_the_right)
+    def execute_sharp_uncomment(self):
+        self._tc.execute_sharp_uncomment()
 
     def Create(self, parent, id, evthandler):
         self._tc = ExpandingContentAssistTextCtrl(

--- a/src/robotide/editor/macroeditors.py
+++ b/src/robotide/editor/macroeditors.py
@@ -51,6 +51,9 @@ class TestCaseEditor(_RobotTableEditor):
     def save(self):
         self.kweditor.save()
 
+    def movecursordown(self):
+        self.kweditor.OnMoveCursorDown()
+
     def undo(self):
         self.kweditor.OnUndo()
 
@@ -69,6 +72,9 @@ class TestCaseEditor(_RobotTableEditor):
     def insert(self):
         self.kweditor.OnInsert()
 
+    def select_all(self, event):
+        self.kweditor.OnSelectAll(event)
+
     def insert_cells(self):
         self.kweditor.OnInsertCells()
 
@@ -85,17 +91,38 @@ class TestCaseEditor(_RobotTableEditor):
     def delete(self):
         self.kweditor.OnDelete()
 
-    def comment(self):
+    def comment_rows(self):
         self.kweditor.OnCommentRows()
 
-    def uncomment(self):
+    def uncomment_rows(self):
         self.kweditor.OnUncommentRows()
 
+    def move_cursor_down(self):
+        self.kweditor.OnMoveCursorDown()
+
+    def move_rows_up(self):
+        self.kweditor.OnMoveRowsUp()
+
+    def move_rows_down(self):
+        self.kweditor.OnMoveRowsDown()
+
+    def swap_row_up(self):
+        self.kweditor.OnSwapRowUp()
+
     def comment_cells(self):
-        self.kweditor.OnCommentCell(None)
+        self.kweditor.OnCommentCells(None)
 
     def uncomment_cells(self):
-        self.kweditor.OnUncommentCell(None)
+        self.kweditor.OnUncommentCells(None)
+
+    def make_variable(self):
+        self.kweditor.OnMakeVariable(None)
+        
+    def make_list_variable(self):
+        self.kweditor.OnMakeListVariable(None)
+        
+    def make_dict_variable(self):
+        self.kweditor.OnMakeDictVariable(None)
 
     def show_content_assist(self):
         self.kweditor.show_content_assist()


### PR DESCRIPTION
This update is only related to shortcuts for the grid editor. That is the Edit pull down menu, the row right click menu and the cell right click menu. The help shortcuts information has been changed as well.
Text editor will follow in another PR.

I left the Content Assist shortcuts to be picked up by me later.
Also I noticed that the Help information sometimes mentions Shift-Ctrl instead of Ctrl-Shift which is in my view the way you say that. Or is there another reason for this difference in help text?

I have added:
Undo / Redo / Move cursor down / Swap Row Up and also changed some text in the menu. Also the order within the different menus is now the same if the same shortcut is active in that menu.