### PR TITLE
Add Chinese language support for 'zh'

### DIFF
--- a/src/robotide/postinstall/__init__.py
+++ b/src/robotide/postinstall/__init__.py
@@ -178,7 +178,7 @@ def _create_desktop_shortcut_linux(frame=None):
     # DEBUG: Add more languages
     desktop = {"de": "Desktop", "en": "Desktop", "es": "Escritorio",
                "fi": r"Työpöytä", "fr": "Bureau", "it": "Scrivania",
-               "pt": r"Área de Trabalho"}
+               "pt": r"Área de Trabalho", "zh": "Desktop"}
     user = getlogin()
     try:
         ndesktop = desktop[DEFAULT_LANGUAGE[0][:2]]


### PR DESCRIPTION
Fixed the issue of not being able to create desktop shortcut icons, successfully tested on Deepin and UOS Linux operating systems

![image](https://github.com/user-attachments/assets/86861899-2762-4037-8df5-d1fd1bb886ea)
![image](https://github.com/user-attachments/assets/a0fb156a-706e-440c-9be5-7ecb354d339c)
![image](https://github.com/user-attachments/assets/225e05ab-01ae-4951-8033-d5c63ddb5f58)



