### PR TITLE
DOCS: fix inconsistent link and git command

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -24,7 +24,7 @@ https://github.com/robotframework/RIDE/issues[issue tracker].
 If you are unsure if something is a bug or is a feature worth
 implementing, you can first ask on link:https://forum.robotframework.org/c/tools/ride/21/[RIDE]
 (RIDE at Forum), or on
-https://robotframework-slack-invite.herokuapp.com[Slack]. These and
+https://slack.robotframework.org/[Slack]. These and
 other similar forums, not the issue tracker, are also places where to
 ask general questions.
 
@@ -124,7 +124,7 @@ Then you may change to the ``develop`` branch, which should be the base for feat
 . ``git pull origin develop``
 . ``git checkout -b a_new_branch_based_on_develop``
 . After changes, you add new files, ``git add a_new_file``
-. You add and commit the modified files, ``git -a -m "The short message with info about the change``
+. You add and commit the modified files, ``git commit -a -m "The short message with info about the change``
 . You push the commit to your fork, ``git push origin a_new_branch_based_on_develop``
 . You may repeat the commit/push and when ready create a Pull Request to your ``develop`` branch, or
 . You checkout your ``develop``branch, and merge with ``git merge a_new_branch_based_on_develop``


### PR DESCRIPTION
- fix an incorrect link redirect to the slack robotframework community.
- add the 'commit' command on the instruction 7 on how to contribute.