### PR TITLE
Modernize print calls to use f-strings

### DIFF
--- a/src/robotide/log/log.py
+++ b/src/robotide/log/log.py
@@ -90,7 +90,7 @@ class LogPlugin(Plugin):
         if self._panel:
             self._panel.update_log()
         if self.log_to_console:
-            print('{}'.format(message_to_string(message)))
+            print(f'{message_to_string(message)}')
         if self.log_to_file:
             self._logfile.write(message_to_string(message))
             self._outfile.flush()

--- a/src/robotide/parserlog/parserlog.py
+++ b/src/robotide/parserlog/parserlog.py
@@ -89,7 +89,7 @@ class ParserLogPlugin(Plugin):
         if self._panel:
             self._panel.update_log()
         if self.log_to_console:
-            print("{}".format(message_to_string(message, True)))  # >> sys.stdout, _message_to_string(message)
+            print(f"{message_to_string(message, True)}")
         if self.log_to_file:
             self._logfile.write(message_to_string(message, True))
             self._outfile.flush()


### PR DESCRIPTION
## Summary
- Convert `.format()` style print calls to f-strings in log output modules
- Related to issue #2554

## Changes
- `src/robotide/log/log.py:93` - Updated print statement to use f-string
- `src/robotide/parserlog/parserlog.py:92` - Updated print statement to use f-string

This is a small contribution towards modernizing the codebase to use Python 3 f-strings consistently.