### PR TITLE
Fix AttributeError: 'Project' object has no attribute 'datafile_controller'

### DIFF
--- a/src/robotide/controller/project.py
+++ b/src/robotide/controller/project.py
@@ -153,6 +153,10 @@ class Project(_BaseController, WithNamespace):
         return self.controller.data if self.controller else None
 
     @property
+    def datafile_controller(self):
+        return self.controller
+
+    @property
     def datafiles(self):
         return self._suites() + self.resources
 

--- a/src/robotide/namespace/suggesters.py
+++ b/src/robotide/namespace/suggesters.py
@@ -110,12 +110,16 @@ class _ImportSuggester(_Suggester):
 
     def get_suggestions(self, name, *args):
         _ = args
+        if self._df_controller is None:
+            return []
         already_imported = self.get_already_imported()
         all_resources = self.get_all_available()
         suggestion_names = all_resources - already_imported
         return [self._suggestion(n) for n in sorted(suggestion_names) if name in n]
 
     def get_already_imported(self):
+        if self._df_controller is None:
+            return set()
         return set(imp.name for imp in self._df_controller.imports)
 
     def get_all_available(self):


### PR DESCRIPTION
## Summary
- Fixes crash when using Library Finder on a clean install without an open project
- Adds `datafile_controller` property to `Project` class
- Adds null checks in `_ImportSuggester` to handle when `datafile_controller` is `None`

## Problem
When RIDE is started fresh (clean install) without an open project, calling `Tools -> Library Finder...` crashes with:
```
AttributeError: 'Project' object has no attribute 'datafile_controller'
```

## Root Cause
`_ImportSuggester.__init__()` calls `controller.datafile_controller`, but `Project` class didn't have this property. The `datafile_controller` attribute only existed on `_DataController` subclasses.

## Solution
1. Added `datafile_controller` property to `Project` class that returns `self.controller` (which may be `None`)
2. Added null checks in `_ImportSuggester.get_suggestions()` and `get_already_imported()` to gracefully handle the case when no project is open

## Testing
- Manually tested the scenario described in the issue
- Library Finder dialog now opens without crashing on a clean install

Closes #2989