### PR TITLE
Fix 'General' settings not available after upgrade (blocks startup)

### DIFF
--- a/src/robotide/application/application.py
+++ b/src/robotide/application/application.py
@@ -147,8 +147,9 @@ class RIDE(wx.App):
         self._controller = Project(self.namespace, self.settings)
         # print(f"DEBUG: application.py RIDE OnInit after defining controller= {self._controller}")
         # Try to get FontInfo as soon as possible
-        font_size = self.settings['General'].get('font size', 12)
-        font_face = self.settings['General'].get('font face', 'Helvetica')
+        general = self.settings.get('General', {})
+        font_size = general.get('font size', 12) if general else 12
+        font_face = general.get('font face', 'Helvetica') if general else 'Helvetica' 
         self.fontinfo = wx.FontInfo(font_size).FaceName(font_face).Bold(False)
         self.fileexplorerplugin = FileExplorerPlugin(self, self._controller)
         self.frame = RideFrame(self, self._controller)

--- a/src/robotide/preferences/settings.cfg
+++ b/src/robotide/preferences/settings.cfg
@@ -1,4 +1,4 @@
-settings_version = 8
+settings_version = 9
 mainframe size = (1100, 700)
 mainframe position = (50, 30)
 mainframe maximized = False

--- a/src/robotide/preferences/settings.py
+++ b/src/robotide/preferences/settings.py
@@ -122,6 +122,8 @@ class SettingsMigrator(object):
             self.migrate_from_6_to_7(self._old_settings)
         if self._old_settings.get(self.SETTINGS_VERSION) == 7:
             self.migrate_from_7_to_8(self._old_settings)
+        if self._old_settings.get(self.SETTINGS_VERSION) == 8:
+            self.migrate_from_8_to_9(self._old_settings)
         self.merge()
 
     def merge(self):
@@ -207,6 +209,28 @@ class SettingsMigrator(object):
                 if os.path.exists(lib_xml_path):
                     os.remove(lib_xml_path)
         settings[self.SETTINGS_VERSION] = 8
+
+    def migrate_from_8_to_9(self, settings):
+        """Ensure General section exists with all required keys."""
+        if 'General' not in settings:
+            settings['General'] = {}
+        general = settings['General']
+        defaults = {
+            'font size': 11,
+            'font face': '',
+            'foreground': '#5E5C64',
+            'background': 'light grey',
+            'secondary foreground': '#DEDDDA',
+            'secondary background': '#0A4A8A',
+            'background help': '#A5F173',
+            'foreground text': '#080240',
+            'apply to panels': False,
+            'ui language': 'English'
+        }
+        for key, value in defaults.items():
+            if key not in general:
+                general[key] = value
+        settings[self.SETTINGS_VERSION] = 9
 
     @staticmethod
     def _key_with_underscore(settings, keyname, section=None):

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -160,14 +160,14 @@ class RideFrame(wx.Frame):
         self.tasks = application.settings.get('tasks', False)
         self.doc_language = application.settings.get('doc language', '')
         self._notebook_theme = application.settings.get('notebook theme', 0)
-        self.general_settings = application.settings['General']  # .get_without_default('General')
-        self.color_background_help = self.general_settings.get('background help', (240, 242, 80))
-        self.color_foreground_text = self.general_settings.get('foreground text', (7, 0, 70))
-        self.color_background = self.general_settings.get_without_default('background')
-        self.color_foreground = self.general_settings.get_without_default('foreground')
-        self.font_face = self.general_settings.get('font face', '')
-        self.font_size = self.general_settings.get('font size', 11)
-        self.ui_language = self.general_settings.get('ui language', 'English')
+        self.general_settings = application.settings.get('General', {})
+        self.color_background_help = self.general_settings.get('background help', (240, 242, 80)) if self.general_settings else (240, 242, 80)
+        self.color_foreground_text = self.general_settings.get('foreground text', (7, 0, 70)) if self.general_settings else (7, 0, 70)
+        self.color_background = self.general_settings.get('background', 'light grey') if self.general_settings else 'light grey'
+        self.color_foreground = self.general_settings.get('foreground', '#5E5C64') if self.general_settings else '#5E5C64'
+        self.font_face = self.general_settings.get('font face', '') if self.general_settings else ''
+        self.font_size = self.general_settings.get('font size', 11) if self.general_settings else 11
+        self.ui_language = self.general_settings.get('ui language', 'English') if self.general_settings else 'English' 
         self.main_menu = None
         self._init_ui()
         self.SetIcon(wx.Icon(self._image_provider.RIDE_ICON))

--- a/src/robotide/ui/treeplugin.py
+++ b/src/robotide/ui/treeplugin.py
@@ -288,9 +288,9 @@ class Tree(treemixin.DragAndDrop, customtreectrl.CustomTreeCtrl, wx.Panel):
         self._RESOURCES_NODE_LABEL = _('External Resources')
         # print(f"DEBUG: treeplugin.py Tree after importing TreeController  __init__ "
         #       f"translated label={self._RESOURCES_NODE_LABEL}")
-        self.theme = settings.get_without_default('General')
-        self.background = self.theme['background']
-        self.foreground = self.theme['foreground']
+        self.theme = settings.get('General', {}) if settings else {}
+        self.background = self.theme.get('background', 'light grey') if self.theme else 'light grey'
+        self.foreground = self.theme.get('foreground', '#5E5C64') if self.theme else '#5E5C64' 
         self._checkboxes_for_tests = False
         self._test_selection_controller = self._create_test_selection_controller()
         self.controller = TreeController(self, action_registerer, settings=settings,

--- a/src/robotide/widgets/dialog.py
+++ b/src/robotide/widgets/dialog.py
@@ -31,16 +31,16 @@ class HtmlWindow(html.HtmlWindow):
         html.HtmlWindow.__init__(self, parent, size=size, style=html.HW_DEFAULT_STYLE)
         from ..preferences import RideSettings
         _settings = RideSettings()
-        self.general_settings = _settings['General']
-        self.color_background_help = color_background if color_background else self.general_settings['background help']
-        self.color_foreground_text = color_foreground if color_foreground else self.general_settings['foreground text']
+        self.general_settings = _settings.get('General', {})
+        self.color_background_help = color_background if color_background else (self.general_settings.get('background help', '#A5F173') if self.general_settings else '#A5F173')
+        self.color_foreground_text = color_foreground if color_foreground else (self.general_settings.get('foreground text', '#080240') if self.general_settings else '#080240')
         self.SetBorders(2)
         self.SetStandardFonts(size=9)
         if text:
             self.set_content(text)
         self.font = self.GetFont()
-        self.font.SetFaceName(self.general_settings['font face'])
-        self.font.SetPointSize(self.general_settings['font size'])
+        self.font.SetFaceName(self.general_settings.get('font face', '') if self.general_settings else '')
+        self.font.SetPointSize(self.general_settings.get('font size', 11) if self.general_settings else 11)
         self.SetFont(self.font)
         self.Refresh(True)
         self.Bind(wx.EVT_KEY_DOWN, self.on_key_down)


### PR DESCRIPTION
## Summary
- Fixes critical bug where RIDE fails to start after upgrade when `'General'` settings section is missing
- Adds settings migration from version 8 to 9 that ensures `General` section exists with all required keys
- Adds safe access to `General` settings in multiple files using `.get()` with fallback values

## Problem
After upgrading RIDE, the application crashes on startup with:
```
KeyError: 'General'
OnInit returned false, exiting...
```

This happens when:
1. User's settings file is corrupted or incomplete
2. Settings migration from older versions doesn't create the `General` section
3. Direct dictionary access `settings['General']` fails

## Root Cause
Multiple files accessed `settings['General']` directly without checking if the section exists:
- `application.py:150` - `self.settings['General'].get('font size', 12)`
- `mainframe.py:163` - `application.settings['General']`
- `treeplugin.py:291` - `settings.get_without_default('General')`
- `dialog.py:34` - `_settings['General']`

## Solution
1. **Added migration `migrate_from_8_to_9()`** - Creates `General` section with default values if missing
2. **Safe dictionary access** - Changed all direct `['General']` access to `.get('General', {})` with fallback values
3. **Defensive coding** - All General settings now have sensible defaults

## Files Modified
- `src/robotide/preferences/settings.py` - Added migration method
- `src/robotide/preferences/settings.cfg` - Updated version to 9
- `src/robotide/application/application.py` - Safe access to font settings
- `src/robotide/ui/mainframe.py` - Safe access to general settings
- `src/robotide/ui/treeplugin.py` - Safe access to theme settings
- `src/robotide/widgets/dialog.py` - Safe access to dialog settings

## Testing
- Tested by simulating missing `General` section in settings
- Application starts successfully with default values
- Existing settings are preserved and merged correctly

Closes #3000