### PR TITLE
Improve error messages with helpful guidance

### DIFF
--- a/src/robotide/editor/customsourceeditor.py
+++ b/src/robotide/editor/customsourceeditor.py
@@ -301,9 +301,11 @@ class CodeEditorPanel(wx.Panel):
             return
         if filepath:
             if filepath != self.path and os.path.isfile(filepath):
-                overwrite_msg = "You are about to overwrite an existing file\n" + \
-                               "Do you want to continue?"
-                dlg = wx.MessageDialog(self, overwrite_msg, "Editor Writer",
+                overwrite_msg = _("You are about to overwrite an existing file.\n\n") + \
+                               _("File: %s\n\n") % filepath + \
+                               _("The existing file will be replaced and cannot be recovered.\n\n") + \
+                               _("Do you want to continue?")
+                dlg = wx.MessageDialog(self, overwrite_msg, _("Confirm Overwrite"),
                                        wx.YES_NO | wx.NO_DEFAULT | wx.ICON_EXCLAMATION)
                 dlg.SetBackgroundColour(Colour(200, 222, 40))
                 dlg.SetForegroundColour(Colour(7, 0, 70))

--- a/src/robotide/editor/texteditor.py
+++ b/src/robotide/editor/texteditor.py
@@ -776,11 +776,16 @@ class DataValidationHandler(object):
             self._editor._mark_file_dirty()
             return False
         # TODO: use widgets.Dialog
-        id = wx.MessageDialog(self._editor,
-                              'ERROR: Data sanity check failed!\n'
-                              'Reset changes?',
-                              'Can not apply changes from Txt Editor',
-                              style=wx.YES | wx.NO).ShowModal()
+        msg = _('ERROR: Data sanity check failed!') + '\n\n' + \
+              _('The text content could not be parsed correctly.') + '\n' + \
+              _('This may be caused by:') + '\n' + \
+              _('  - Invalid Robot Framework syntax') + '\n' + \
+              _('  - Malformed table or section headers') + '\n' + \
+              _('  - Incorrect indentation or spacing') + '\n\n' + \
+              _('Reset changes?')
+        id = wx.MessageDialog(self._editor, msg,
+                              _('Can not apply changes from Text Editor'),
+                              style=wx.YES | wx.NO | wx.ICON_ERROR).ShowModal()
         self._last_answer = id
         self._last_answer_time = time()
         if id == wx.ID_YES:
@@ -907,8 +912,12 @@ class DataValidationHandler(object):
             # self.source_editor._mark_file_dirty(True)
             return False
         dlg = RIDEDialog(title=_("Can not apply changes from Text Editor"),
-                         message=f"{_('ERROR: Data sanity check failed!')}\n{_('Error at line')}"
-                                 f" {message[1]}:\n{message[0]}\n\n{_('Reset changes?')}",
+                         message=f"{_('ERROR: Data sanity check failed!')}\n\n"
+                                 f"{_('Error at line')} {message[1]}:\n"
+                                 f"  {message[0]}\n\n"
+                                 f"{_('This may be caused by invalid syntax or formatting.')}\n"
+                                 f"{_('Check the line and fix the error, or reset changes.')}\n\n"
+                                 f"{_('Reset changes?')}",
                          style=wx.ICON_ERROR | wx.YES_NO)
         dlg.InheritAttributes()
         did = dlg.ShowModal()

--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -216,15 +216,23 @@ class RideFrame(wx.Frame):
 
     @staticmethod
     def _show_validation_error(message):
-        message_box = RIDEDialog(title=_('Validation Error'), message=message.message, style=wx.ICON_ERROR|wx.OK)
+        error_msg = message.message
+        help_text = "\n\n" + _("Common causes:") + "\n" +                     _("  - Invalid characters in name") + "\n" +                     _("  - Name too long or empty") + "\n" +                     _("  - Duplicate name already exists")
+        message_box = RIDEDialog(title=_('Validation Error'), 
+                                 message=error_msg + help_text,
+                                 style=wx.ICON_ERROR|wx.OK)
         message_box.ShowModal()
 
     @staticmethod
     def _show_modification_prevented_error(message):
+        filename = message.controller.datafile_controller.filename
         message_box = RIDEDialog(title=_("Modification prevented"),
-                                 message=_("\"%s\" is read only") % message.controller.datafile_controller.filename,
+                                 message=_("\"%s\" is read only.\n\n") % filename +
+                                          _("To make changes:\n") +
+                                          _("  1. Close the file in RIDE\n") +
+                                          _("  2. Change file permissions in your file manager\n") +
+                                          _("  3. Reopen the file in RIDE"),
                                  style=wx.ICON_ERROR|wx.OK)
-        # message_box.CenterOnParent()
         message_box.ShowModal()
 
     def _init_ui(self):


### PR DESCRIPTION
## Summary
Improves error messages throughout RIDE to provide more helpful guidance to users when things go wrong.

## Changes
- Text editor sanity check errors now show possible causes (invalid syntax, malformed headers, indentation issues)
- Validation errors now show common causes (invalid characters, name too long/empty, duplicate names)
- Modification prevented error now shows step-by-step solution (how to change file permissions)
- File overwrite dialog now shows filename and warns about recovery
- All dialogs now use proper localization with _()
- Added error icons to dialogs for better visibility