### PR TITLE
fix: recognize variable-width space separators

### DIFF
--- a/src/robotide/lib/robot/parsing/robotreader.py
+++ b/src/robotide/lib/robot/parsing/robotreader.py
@@ -170,23 +170,11 @@ class RobotReader(object):
                 return
             if not self._cell_section:
                 return
-            spc = idx = nospc = 0
-            for idx in range(0, len(line)):
-                if line[idx] != ' ':
-                    nospc += 1
-                    # if spc <= 2:
-                    #     spc = -1
-                    #
-                    if spc >= 2:
-                        break
-                    spc = 0
-                elif line[idx] == ' ':  # and nospc > 0:
-                    spc += 1
-            if nospc > 0 and spc < 2:  # We need a step, not test case or kw name (nospc == 0 and spc <= 2 or )
+            content = line.lstrip(' \t\xa0')
+            separator = re.search(r"[ \xa0]{2,}|\t+", content)
+            if not separator:
                 return
-            spc = max(2, spc)
-            if 2 <= spc <= 10:  # This max limit is reasonable
-                self._spaces = spc
-                self._space_splitter = re.compile(r"[ \t\xa0]{" + f"{self._spaces}" + "}|\t+")
-                self._separator_check = True
-                # print(f"DEBUG: RFLib RobotReader check_separator changed spaces={self._spaces}")
+            self._spaces = max(2, len(separator.group()))
+            self._space_splitter = re.compile(r"[ \xa0]{2,}|\t+")
+            self._separator_check = True
+            # print(f"DEBUG: RFLib RobotReader check_separator changed spaces={self._spaces}")

--- a/utest/lib/robot/parsing/test_robotreader.py
+++ b/utest/lib/robot/parsing/test_robotreader.py
@@ -1,0 +1,17 @@
+from robotide.lib.robot.parsing.robotreader import RobotReader
+
+
+def test_reads_two_space_separators_when_four_spaces_are_configured():
+    reader = RobotReader(spaces=4, lang=["en"])
+    reader.check_separator("*** Test Cases ***")
+    reader.check_separator("First test case")
+    row = "    Keyword with two arguments  arg1  arg2"
+
+    reader.check_separator(row)
+
+    assert reader.split_row(row) == [
+        "",
+        "Keyword with two arguments",
+        "arg1",
+        "arg2",
+    ]


### PR DESCRIPTION
## Summary

- I updated separator detection to recognize Robot Framework's two-or-more-space separators even when RIDE is configured to write four spaces.
- I kept tab separators supported and added a regression test for the reported four-space configuration with a two-space input file.

## Testing

- `xvfb-run -a python -m pytest -q utest/lib/robot/parsing/test_robotreader.py` — 1 passed
- `python -m py_compile src/robotide/lib/robot/parsing/robotreader.py utest/lib/robot/parsing/test_robotreader.py`
- `git diff --check origin/develop...HEAD`

I also attempted the full `invoke test` suite locally. Its first application pass completed with 15 passed and 3 skipped, but the main run reported failures in `utest/controller/test_cellinfo.py` and `utest/application/test_postinstaller.py` before timing out while running `utest/application/test_updatenotifier.py`.

Fixes #3045
